### PR TITLE
yAudit audit I7 fix

### DIFF
--- a/src/EthereumVaultConnector.sol
+++ b/src/EthereumVaultConnector.sol
@@ -667,6 +667,10 @@ contract EthereumVaultConnector is Events, Errors, TransientStorage, IEVC {
 
     /// @inheritdoc IEVC
     function isAccountStatusCheckDeferred(address account) external view returns (bool) {
+        if (executionContext.areChecksInProgress()) {
+            revert EVC_ChecksReentrancy();
+        }
+
         return accountStatusChecks.contains(account);
     }
 
@@ -705,6 +709,10 @@ contract EthereumVaultConnector is Events, Errors, TransientStorage, IEVC {
 
     /// @inheritdoc IEVC
     function isVaultStatusCheckDeferred(address vault) external view returns (bool) {
+        if (executionContext.areChecksInProgress()) {
+            revert EVC_ChecksReentrancy();
+        }
+
         return vaultStatusChecks.contains(vault);
     }
 

--- a/test/unit/EthereumVaultConnector/IsAccountStatusCheckDeferred.t.sol
+++ b/test/unit/EthereumVaultConnector/IsAccountStatusCheckDeferred.t.sol
@@ -34,4 +34,13 @@ contract IsAccountStatusCheckDeferredTest is Test {
             evc.reset();
         }
     }
+
+    function test_RevertIfChecksInProgress_IsAccountStatusCheckDeferred(address account) external {
+        evc.setChecksLock(false);
+        assertFalse(evc.isAccountStatusCheckDeferred(account));
+
+        evc.setChecksLock(true);
+        vm.expectRevert(Errors.EVC_ChecksReentrancy.selector);
+        evc.isAccountStatusCheckDeferred(account);
+    }
 }

--- a/test/unit/EthereumVaultConnector/IsVaultStatusCheckDeferred.t.sol
+++ b/test/unit/EthereumVaultConnector/IsVaultStatusCheckDeferred.t.sol
@@ -36,4 +36,13 @@ contract IsVaultStatusCheckDeferredTest is Test {
             evc.reset();
         }
     }
+
+    function test_RevertIfChecksInProgress_IsVaultStatusCheckDeferred(address vault) external {
+        evc.setChecksLock(false);
+        assertFalse(evc.isVaultStatusCheckDeferred(vault));
+
+        evc.setChecksLock(true);
+        vm.expectRevert(Errors.EVC_ChecksReentrancy.selector);
+        evc.isVaultStatusCheckDeferred(vault);
+    }
 }


### PR DESCRIPTION
https://github.com/yAudit/euler-evc-report#7-informational---isaccountstatuscheckdeferred-and-isvaultstatuscheckdeferred-will-return-false-during-checks-callback