### PR TITLE
Amend CER-51-Permit-msg-sender post updates for controlCollateral

### DIFF
--- a/certora/harness/EthereumVaultConnectorHarness.sol
+++ b/certora/harness/EthereumVaultConnectorHarness.sol
@@ -43,4 +43,7 @@ contract EthereumVaultConnectorHarness is EthereumVaultConnector {
         return accountControllers[account].firstElement;
 
     }
+    function isAccountController(address account, address controller) public view returns (bool) {
+        return accountControllers[account].contains(controller);
+    }
 }

--- a/certora/harness/EthereumVaultConnectorHarness.sol
+++ b/certora/harness/EthereumVaultConnectorHarness.sol
@@ -39,4 +39,8 @@ contract EthereumVaultConnectorHarness is EthereumVaultConnector {
         bytes19 addressPrefix = getAddressPrefixInternal(account);
         return operatorLookup[addressPrefix][operator];
     }
+    function getAccountController(address account) public view returns (address) {
+        return accountControllers[account].firstElement;
+
+    }
 }

--- a/certora/specs/CER-15-Permit/CER-51-Permit-msg-sender.spec
+++ b/certora/specs/CER-15-Permit/CER-51-Permit-msg-sender.spec
@@ -81,7 +81,9 @@ hook CALL(uint g, address addr, uint value, uint argsOffset, uint argsLength, ui
 
 // This rule checks the property of interest "EVC can only be msg.sender during the self-call in the permit() function. Expected to fail on permit() function.
 // To prove this for controlCollateral, we need the additionl assumption
-// that the EVC can never become an account controller. (See the rule after this one)
+// that the EVC can never become an account controller. (See the rule after this one). We also prove this assumption
+// CER-80: https://linear.app/euler-labs/issue/CER-80/collaterals-restrictions
+
 rule onlyEVCCanCallCriticalMethod(method f, env e, calldataarg args)
   filtered {f -> 
     !isMustRevertFunction(f) &&

--- a/certora/specs/CER-15-Permit/CER-51-Permit-msg-sender.spec
+++ b/certora/specs/CER-15-Permit/CER-51-Permit-msg-sender.spec
@@ -94,6 +94,8 @@ rule onlyEVCCanCallCriticalMethod(method f, env e, calldataarg args)
 
 // For onlyController we need the additional assumption that
 // the EVC ("currentContract") can never become a controller.
+// NOTE: We will eventually prove this assumption to satisfy
+// https://linear.app/euler-labs/issue/CER-81/controllers-restrictions
 rule onlyEVCCanCallCriticalMethodOnlyController {
     env e;
     address targetCollateral;

--- a/certora/specs/CER-15-Permit/CER-51-Permit-msg-sender.spec
+++ b/certora/specs/CER-15-Permit/CER-51-Permit-msg-sender.spec
@@ -7,6 +7,9 @@ import "../utils/CallOpSanity.spec";
 
 methods {
     function getAccountController(address account) external returns (address) envfree;
+    function isCollateralEnabled(address account, address vault) external returns (bool) envfree;
+    function isAccountController(address account, address controller) external returns (bool) envfree;
+
 }
 
 ////////////////////////////////////////////////////////////////
@@ -93,9 +96,9 @@ rule onlyEVCCanCallCriticalMethod(method f, env e, calldataarg args)
 }
 
 // For onlyController we need the additional assumption that
-// the EVC ("currentContract") can never become a controller.
+// the EVC ("currentContract") can never become a collateral for any address.
 // NOTE: We will eventually prove this assumption to satisfy
-// https://linear.app/euler-labs/issue/CER-81/controllers-restrictions
+// CER-80: https://linear.app/euler-labs/issue/CER-80/collaterals-restrictions
 rule onlyEVCCanCallCriticalMethodOnlyController {
     env e;
     address targetCollateral;
@@ -104,7 +107,7 @@ rule onlyEVCCanCallCriticalMethodOnlyController {
     bytes data;
 
     require(e.msg.sender != currentContract);
-    require getAccountController(onBehalfOfAccount) != currentContract;
+    require !isCollateralEnabled(onBehalfOfAccount, currentContract);
     controlCollateral(e, targetCollateral, onBehalfOfAccount, value, data);
 
     assert(true);

--- a/certora/specs/CER-15-Permit/CER-51-Permit-msg-sender.spec
+++ b/certora/specs/CER-15-Permit/CER-51-Permit-msg-sender.spec
@@ -72,11 +72,12 @@ hook CALL(uint g, address addr, uint value, uint argsOffset, uint argsLength, ui
     assert(executingContract != currentContract || addr != currentContract);
 }
 
-// This rule checks the property of interest "EVC can only be msg.sender during the self-call in the permit() function". Expected to fail on permit() function.
+// This rule checks the property of interest "EVC can only be msg.sender during the self-call in the permit() function or controlCollateral". Expected to fail on permit() function.
 rule onlyEVCCanCallCriticalMethod(method f, env e, calldataarg args)
   filtered {f -> 
     !isMustRevertFunction(f) &&
-    f.selector != sig:EthereumVaultConnectorHarness.permit(address,uint256,uint256,uint256,uint256,bytes,bytes).selector
+    f.selector != sig:EthereumVaultConnectorHarness.permit(address,uint256,uint256,uint256,uint256,bytes,bytes).selector &&
+    f.selector != sig:EthereumVaultConnectorHarness.controlCollateral(address, address, uint256, bytes).selector
   }{
     //Exclude EVC as being the initiator of the call.
     require(e.msg.sender != currentContract);


### PR DESCRIPTION
Update CER-51 for controlCollateral which must apply CER-80 as an assumption (that we also prove) https://linear.app/euler-labs/issue/CER-80/collaterals-restrictions