### PR TITLE
CER-78

### DIFF
--- a/certora/conf/CER-44-VaultStatusCheck/CER-78-VaultStatusCheck-scheduling.conf
+++ b/certora/conf/CER-44-VaultStatusCheck/CER-78-VaultStatusCheck-scheduling.conf
@@ -5,6 +5,7 @@
     ],
     "verify": "EthereumVaultConnectorHarness:certora/specs/CER-44-VaultStatusCheck/CER-78-VaultStatusCheck-scheduling.spec",
     "solc_via_ir" : true,
+    "function_finder_mode" : "relaxed",
     "rule_sanity": "basic",
     "assert_autofinder_success" : true,
     "optimistic_loop": true,

--- a/certora/conf/CER-44-VaultStatusCheck/CER-78-VaultStatusCheck-scheduling.conf
+++ b/certora/conf/CER-44-VaultStatusCheck/CER-78-VaultStatusCheck-scheduling.conf
@@ -1,9 +1,9 @@
 {
     "files": [
-        "src/EthereumVaultConnector.sol",
         "certora/harness/EthereumVaultConnectorHarness.sol"
     ],
     "verify": "EthereumVaultConnectorHarness:certora/specs/CER-44-VaultStatusCheck/CER-78-VaultStatusCheck-scheduling.spec",
+    "parametric_contracts": ["EthereumVaultConnectorHarness"],
     "solc_via_ir" : true,
     "function_finder_mode" : "relaxed",
     "rule_sanity": "basic",

--- a/certora/conf/CER-44-VaultStatusCheck/CER-78-VaultStatusCheck-scheduling.conf
+++ b/certora/conf/CER-44-VaultStatusCheck/CER-78-VaultStatusCheck-scheduling.conf
@@ -1,0 +1,15 @@
+{
+    "files": [
+        "src/EthereumVaultConnector.sol",
+        "certora/harness/EthereumVaultConnectorHarness.sol"
+    ],
+    "verify": "EthereumVaultConnectorHarness:certora/specs/CER-44-VaultStatusCheck/CER-78-VaultStatusCheck-scheduling.spec",
+    "solc_via_ir" : true,
+    "rule_sanity": "basic",
+    "assert_autofinder_success" : true,
+    "optimistic_loop": true,
+    "optimistic_hashing": true,
+    "solc_optimize" :  "10000",
+    "msg" : "CER-44-VaultStatusCheck/CER-78-VaultStatusCheck-scheduling",
+    "solc": "solc8.20"
+}

--- a/certora/harness/EthereumVaultConnectorHarness.sol
+++ b/certora/harness/EthereumVaultConnectorHarness.sol
@@ -48,10 +48,6 @@ contract EthereumVaultConnectorHarness is EthereumVaultConnector {
         (bool isValid, ) = checkVaultStatusInternal(vault);
         return isValid;
     }
-    function requireVaultStatusCheck(address vault) external {
-       requireVaultStatusCheckInternal(vault);
-    }
-
     function areAccountStatusChecksEmpty() public view returns (bool) {
         return accountStatusChecks.numElements == 0;
     }

--- a/certora/harness/EthereumVaultConnectorHarness.sol
+++ b/certora/harness/EthereumVaultConnectorHarness.sol
@@ -44,6 +44,13 @@ contract EthereumVaultConnectorHarness is EthereumVaultConnector {
     function requireAccountStatusCheckInternalHarness(address account) public {
         requireAccountStatusCheckInternal(account);
     }
+    function checkVaultStatus(address vault) public returns (bool) {
+        (bool isValid, ) = checkVaultStatusInternal(vault);
+        return isValid;
+    }
+    function requireVaultStatusCheck(address vault) external {
+       requireVaultStatusCheckInternal(vault);
+    }
 
     function areAccountStatusChecksEmpty() public view returns (bool) {
         return accountStatusChecks.numElements == 0;

--- a/certora/specs/CER-44-VaultStatusCheck/CER-78-VaultStatusCheck-scheduling.spec
+++ b/certora/specs/CER-44-VaultStatusCheck/CER-78-VaultStatusCheck-scheduling.spec
@@ -10,8 +10,10 @@ methods {
     // call that the set of vault addresses did not already contain
     // some vault address other than e.msg.sender.
     // These summaries exclude the deferred checks from the rule.
+    // To strengthen this we also show that the vaultStatusChecks set can
+    // only be modified for e.msg.sender 
     function EthereumVaultConnector.checkStatusAll(TransientStorage.SetType setType) internal => NONDET;
-    function EthereumVaultConnector.restoreExecutionContext(ExecutionContext.EC ec) internal => NONDET;
+    function EthereumVaultConnector.restoreExecutionContext(EthereumVaultConnectorHarness.EC ec) internal => NONDET;
 }
 
 // In all contexts where requireVaultStatusCheckInternal is called,
@@ -37,4 +39,31 @@ rule vault_status_check_scheduling (method f) filtered { f ->
     f(e, args);
     // Check: we have never run requireVaultStatusCheck with the wrong sender.
     assert onlyVault;
+}
+
+persistent ghost bool onlyInsertSender;
+persistent ghost address savedSender;
+hook Sstore currentContract.vaultStatusChecks.elements[INDEX uint256 _index].value address newValue (address oldValue) STORAGE {
+    onlyInsertSender = onlyInsertSender && (newValue == savedSender);
+}
+hook Sstore currentContract.vaultStatusChecks.firstElement address newValue STORAGE {
+    onlyInsertSender = onlyInsertSender && (newValue == savedSender);
+}
+
+rule insert_status_checks_only_by_sender (method f) filtered {f ->
+    !isMustRevertFunction(f) &&
+    // The following is needed because of a limitation in our specifications. 
+    // To show that this holds also for forgiveVaultStatusCheck we would need
+    // to rewrite the set library in a more modular way so we can import it 
+    // here. ForgiveVaultStatusCheck() directly calls remove on e.msg.sender
+    // so by looking at the code this clearly can only affect e.msg.sender
+    // and also only removes status checks rather than adding them.
+    f.selector != sig:EthereumVaultConnectorHarness.forgiveVaultStatusCheck().selector
+}{
+    env e;
+    calldataarg args;
+    savedSender = e.msg.sender;
+    require onlyInsertSender;
+    f(e, args);
+    assert onlyInsertSender;
 }

--- a/certora/specs/CER-44-VaultStatusCheck/CER-78-VaultStatusCheck-scheduling.spec
+++ b/certora/specs/CER-44-VaultStatusCheck/CER-78-VaultStatusCheck-scheduling.spec
@@ -9,6 +9,7 @@ methods {
     // when the deferred checks are executed at the end of the deferred check
     // call that the set of vault addresses did not already contain
     // some vault address other than e.msg.sender.
+    // These summaries exclude the deferred checks from the rule.
     function EthereumVaultConnector.checkStatusAll(TransientStorage.SetType setType) internal => NONDET;
     function EthereumVaultConnector.restoreExecutionContext(ExecutionContext.EC ec) internal => NONDET;
 }

--- a/certora/specs/CER-44-VaultStatusCheck/CER-78-VaultStatusCheck-scheduling.spec
+++ b/certora/specs/CER-44-VaultStatusCheck/CER-78-VaultStatusCheck-scheduling.spec
@@ -6,9 +6,18 @@ methods {
     function EthereumVaultConnector.requireVaultStatusCheckInternal(address vault) internal with (env e) => requireVaultStatusCheckOnlyCalledBySelf(e, vault);
 }
 
+function actualCaller(env e) returns address {
+    if(e.msg.sender == currentContract) {
+        return getExecutionContextOnBehalfOfAccount(e);
+    } else {
+        return e.msg.sender;
+    }
+}
+
+// In all contexts where requireVaultStatusCheckInternal is called,
+// the caller should be the vault. 
 function requireVaultStatusCheckOnlyCalledBySelf(env e, address vault) {
     assert e.msg.sender == vault;
-    requireVaultStatusCheck(e, vault);
 }
 
 rule vault_status_check_scheduling (method f) filtered { f ->

--- a/certora/specs/CER-44-VaultStatusCheck/CER-78-VaultStatusCheck-scheduling.spec
+++ b/certora/specs/CER-44-VaultStatusCheck/CER-78-VaultStatusCheck-scheduling.spec
@@ -35,8 +35,9 @@ function actualCaller(env e) returns address {
 
 // In all contexts where requireVaultStatusCheckInternal is called,
 // the caller should be the vault. 
+persistent ghost bool onlyVault;
 function requireVaultStatusCheckOnlyCalledBySelf(env e, address vault) {
-    assert e.msg.sender == vault;
+    onlyVault = onlyVault &&  e.msg.sender == vault;
 }
 
 rule vault_status_check_scheduling (method f) filtered { f ->
@@ -49,11 +50,12 @@ rule vault_status_check_scheduling (method f) filtered { f ->
 }{
     env e;
     calldataarg args;
+    require onlyVault;
     // The point of this rule is to check that in all contexts in which 
     // requireVaultStatusCheck is called, the vault is the message sender
     // If requireVaultStatusCheck is reachable from the function called
     // it will invoke the assertion in requireVaultStatusCheckOnlyCalledBySelf
     f(e, args);
     // This is just here to make this a valid rule
-    satisfy true;
+    assert onlyVault;
 }

--- a/certora/specs/CER-44-VaultStatusCheck/CER-78-VaultStatusCheck-scheduling.spec
+++ b/certora/specs/CER-44-VaultStatusCheck/CER-78-VaultStatusCheck-scheduling.spec
@@ -1,0 +1,26 @@
+import "../utils/IsMustRevertFunction.spec";
+
+// CER-78: Vault Status Check scheduling
+// Only the Vault is allowed require the check for itself
+methods {
+    function EthereumVaultConnector.requireVaultStatusCheckInternal(address vault) internal with (env e) => requireVaultStatusCheckOnlyCalledBySelf(e, vault);
+}
+
+function requireVaultStatusCheckOnlyCalledBySelf(env e, address vault) {
+    assert e.msg.sender == vault;
+    requireVaultStatusCheck(e, vault);
+}
+
+rule vault_status_check_scheduling (method f) filtered { f ->
+    !isMustRevertFunction(f)
+}{
+    env e;
+    calldataarg args;
+    // The point of this rule is to check that in all contexts in which 
+    // requireVaultStatusCheck is called, the vault is the message sender
+    // If requireVaultStatusCheck is reachable from the function called
+    // it will invoke the assertion in requireVaultStatusCheckOnlyCalledBySelf
+    f(e, args);
+    // This is just here to make this a valid rule
+    satisfy true;
+}

--- a/certora/specs/CER-44-VaultStatusCheck/CER-78-VaultStatusCheck-scheduling.spec
+++ b/certora/specs/CER-44-VaultStatusCheck/CER-78-VaultStatusCheck-scheduling.spec
@@ -4,8 +4,27 @@ import "../utils/IsMustRevertFunction.spec";
 // Only the Vault is allowed require the check for itself
 methods {
     function EthereumVaultConnector.requireVaultStatusCheckInternal(address vault) internal with (env e) => requireVaultStatusCheckOnlyCalledBySelf(e, vault);
+    // This summarization does not work see note
+    // function EthereumVaultConnector.callWithContextInternal(address targetContract, address onBehalfOfAccount, uint256 value, bytes calldata data) internal returns (bool, bytes memory) => NONDET;
+    // function EthereumVaultConnector.callWithContextInternal(address targetContract, address onBehalfOfAccount, uint256 value, bytes calldata data) internal returns (bool, bytes memory) => CallWithContextInternalSummary(targetContract, onBehalfOfAccount, value, data);
+
 }
 
+/*
+ * This summarization does not work:
+ CRITICAL: [main] ERROR ALWAYS - Error in spec file (CER-78-VaultStatusCheck-scheduling.spec:15:9): could not type expression "CallResult(targetContract, onBehalfOfAccount, value, convert_hashblob(data))", message: Expected type bytes in return position 2 of CVL function CallWithContextInternalSummary, but CallResult(targetContract, onBehalfOfAccount, value, convert_hashblob(data)) is of type hashblob
+*/
+// function CallWithContextInternalSummary(address targetContract, address onBehalfOfAccount, uint256 value, bytes data) returns (bool, bytes) {
+//     return (
+//         CallSuccess(targetContract, onBehalfOfAccount, value, data),
+//         CallResult(targetContract, onBehalfOfAccount, value, data)
+//     );
+// }
+// ghost CallSuccess(address, address, uint256, bytes) returns bool;
+// ghost CallResult(address, address, uint256, bytes) returns bytes;
+
+
+// NOTE: not used. delete or refactor if it becomes used
 function actualCaller(env e) returns address {
     if(e.msg.sender == currentContract) {
         return getExecutionContextOnBehalfOfAccount(e);
@@ -22,6 +41,11 @@ function requireVaultStatusCheckOnlyCalledBySelf(env e, address vault) {
 
 rule vault_status_check_scheduling (method f) filtered { f ->
     !isMustRevertFunction(f)
+    // These functions we have trouble reasoning about because
+    // they involve callWithContextInternal
+    && f.selector != sig:batch(IEVC.BatchItem[] calldata).selector
+    && f.selector != sig:call(address, address, uint256, bytes calldata).selector
+    && f.selector != sig:controlCollateral(address, address, uint256, bytes).selector
 }{
     env e;
     calldataarg args;


### PR DESCRIPTION
Implements CER-78: https://linear.app/euler-labs/issue/CER-78/vault-status-check-scheduling.

For now we need to make a few calls out of scope, but we may be able to cover them if we can reason about the calls in callWithContextInternal better. 