### PR TITLE
Fix broken spec after recent update

### DIFF
--- a/certora/harness/EthereumVaultConnectorHarness.sol
+++ b/certora/harness/EthereumVaultConnectorHarness.sol
@@ -11,7 +11,7 @@ contract EthereumVaultConnectorHarness is EthereumVaultConnector {
     using Set for SetStorage;
 
     function getExecutionContextDefault() external view returns (uint256) {
-        return EC.unwrap(ExecutionContext.initialize());
+        return ExecutionContext.STAMP_DUMMY_VALUE << ExecutionContext.STAMP_OFFSET;
     }
 
     function getExecutionContextAreChecksDeferred() external view returns (bool) {


### PR DESCRIPTION
This recent commit: https://github.com/euler-xyz/ethereum-vault-connector/commit/d912753371658831e9bc048b7c2c006743bd3623 Changes how initialization works, so it is no longer the default value needed for CER-38 causing the invariant to fail. This PR just updates our harness to repair this.

Run with updated default: https://prover.certora.com/output/65266/9ff51a4bb5f84119a9d37bcddfd06ddf?anonymousKey=32a5bcd5cbb34bf68ae9ab84feaf069813bf7e74