### PR TITLE
Fix bad merge breaking CER-38

### DIFF
--- a/certora/harness/EthereumVaultConnectorHarness.sol
+++ b/certora/harness/EthereumVaultConnectorHarness.sol
@@ -61,9 +61,6 @@ contract EthereumVaultConnectorHarness is EthereumVaultConnector {
         return accountCollaterals[account].get();
     }
 
-    function getAccountController(address account) public view returns (address) {
-        return accountControllers[account].firstElement;
-    }
     function isAccountController(address account, address controller) public view returns (bool) {
         return accountControllers[account].contains(controller);
     }

--- a/certora/harness/EthereumVaultConnectorHarness.sol
+++ b/certora/harness/EthereumVaultConnectorHarness.sol
@@ -48,6 +48,9 @@ contract EthereumVaultConnectorHarness is EthereumVaultConnector {
     function areAccountStatusChecksEmpty() public view returns (bool) {
         return accountStatusChecks.numElements == 0;
     }
+    function areVaultStatusChecksEmpty() public view returns (bool) {
+        return vaultStatusChecks.numElements == 0;
+    }
     
     function getOperatorFromAddress(address account, address operator) external view returns (uint256) {
         bytes19 addressPrefix = getAddressPrefixInternal(account);


### PR DESCRIPTION
I apparently deleted a function that was needed in the harness for CER-38 and added duplicate for another when resolving merge conflicts. I assumed the other approved rules were failing because they were not based on the fix to CER-38 previously -- I was trying to save you some extra work to re-review the code which would have been needed if I rebased. Sorry about this!