### PR TITLE
Eliminate dead and obsolete code

### DIFF
--- a/certora/harness/ExecutionContextHarness.sol
+++ b/certora/harness/ExecutionContextHarness.sol
@@ -52,8 +52,4 @@ contract ExecutionContextHarness {
         result = ExecutionContext.setSimulationInProgress(context);
     }
 
-    function initialize() external pure returns (EC result) {
-        result = ExecutionContext.initialize();
-    }
-
 }

--- a/certora/specs/misc/ExecutionContext.spec
+++ b/certora/specs/misc/ExecutionContext.spec
@@ -9,7 +9,6 @@ methods {
     function clearOperatorAuthenticated(ExecutionContextHarness.EC context) external returns (ExecutionContextHarness.EC) envfree;
     function isSimulationInProgress(ExecutionContextHarness.EC context) external returns (bool) envfree;
     function setSimulationInProgress(ExecutionContextHarness.EC context) external returns (ExecutionContextHarness.EC) envfree;
-    function initialize() external returns (ExecutionContextHarness.EC) envfree;
 }
 
 /// check basic functionality of getOnBehalfOfAccount and setOnBehalfOfAccount


### PR DESCRIPTION
Somehow this just causes a warning, but it is neither up to date nor actually used anywhere, so it's best to delete.