### PR TITLE
Omniscia audit

### DIFF
--- a/docs/whitepaper.md
+++ b/docs/whitepaper.md
@@ -306,7 +306,7 @@ To improve user security, the EVC introduces the `LOCKDOWN MODE`. This mode, whi
 
 ### Permit Disabled Mode
 
-Another feature to improve user security is the `PERMIT DISABLED MODE`. This mode, which can only be activated by the owner, applies to all their accounts simultaneously. Once activated, the EVC no longer allows executing permits that were signed by the owner which activated this mode. This mode is particularly useful in emergency situations, such as when a harmful permit message has been signed, necessitating immediate action to safeguard the user's assets. The `PERMIT DISABLED MODE` is a subset of the `LOCKDOWN MODE` which is more restrictive.
+Another feature to improve user security is the `PERMIT DISABLED MODE`. This mode, which can only be activated by the owner, applies to all their accounts simultaneously. Once activated, the EVC no longer allows executing permits that were signed by the owner which activated this mode. This mode is particularly useful in emergency situations, such as when a harmful permit message has been signed, necessitating immediate action to safeguard the user's assets.
 
 ### Authentication by Vaults
 

--- a/src/EthereumVaultConnector.sol
+++ b/src/EthereumVaultConnector.sol
@@ -109,7 +109,7 @@ contract EthereumVaultConnector is Events, Errors, TransientStorage, IEVC {
         // calculate a phantom address from the address prefix which can be used as an input to the authenticateCaller()
         // function
         address phantomAccount = address(uint160(uint152(addressPrefix)) << 8);
-        authenticateCaller(phantomAccount, false, false);
+        authenticateCaller({account: phantomAccount, allowOperator: false, checkLockdownMode: false});
 
         _;
     }
@@ -121,7 +121,7 @@ contract EthereumVaultConnector is Events, Errors, TransientStorage, IEVC {
     /// @param account The address of the account for which it is checked whether the caller is the owner or an
     /// operator.
     modifier onlyOwnerOrOperator(address account) {
-        authenticateCaller(account, true, true);
+        authenticateCaller({account: account, allowOperator: true, checkLockdownMode: true});
 
         _;
     }
@@ -334,7 +334,8 @@ contract EthereumVaultConnector is Events, Errors, TransientStorage, IEVC {
         // calculate a phantom address from the address prefix which can be used as an input to the authenticateCaller()
         // function
         address phantomAccount = address(uint160(uint152(addressPrefix)) << 8);
-        address msgSender = authenticateCaller(phantomAccount, false, false);
+        address msgSender =
+            authenticateCaller({account: phantomAccount, allowOperator: false, checkLockdownMode: false});
 
         // the operator can neither be the EVC nor can be one of 256 accounts of the owner
         if (operator == address(this) || haveCommonOwnerInternal(msgSender, operator)) {
@@ -354,7 +355,7 @@ contract EthereumVaultConnector is Events, Errors, TransientStorage, IEVC {
     /// @dev Uses authenticateCaller() function instead of onlyOwnerOrOperator() modifier to authenticate and get the
     /// caller address at once.
     function setAccountOperator(address account, address operator, bool authorized) public payable virtual {
-        address msgSender = authenticateCaller(account, true, false);
+        address msgSender = authenticateCaller({account: account, allowOperator: true, checkLockdownMode: false});
 
         // if the account and the caller have a common owner, the caller must be the owner. if the account and the
         // caller don't have a common owner, the caller must be an operator and the owner address is taken from the
@@ -834,7 +835,7 @@ contract EthereumVaultConnector is Events, Errors, TransientStorage, IEVC {
             // when the target contract is equal to the msg.sender, both in call() and batch(), authentication is not
             // required
             if (targetContract != msg.sender) {
-                authenticateCaller(onBehalfOfAccount, true, true);
+                authenticateCaller({account: onBehalfOfAccount, allowOperator: true, checkLockdownMode: true});
             }
 
             (success, result) = callWithContextInternal(targetContract, onBehalfOfAccount, value, data);

--- a/src/EthereumVaultConnector.sol
+++ b/src/EthereumVaultConnector.sol
@@ -854,7 +854,7 @@ contract EthereumVaultConnector is Events, Errors, TransientStorage, IEVC {
         address controller = accountControllers[account].firstElement;
 
         if (numOfControllers == 0) return (true, "");
-        else if (numOfControllers > 1) revert EVC_ControllerViolation();
+        else if (numOfControllers > 1) return (false, abi.encodeWithSelector(EVC_ControllerViolation.selector));
 
         bool success;
         (success, result) =

--- a/src/EthereumVaultConnector.sol
+++ b/src/EthereumVaultConnector.sol
@@ -71,7 +71,7 @@ contract EthereumVaultConnector is Events, Errors, TransientStorage, IEVC {
         bool isPermitDisabledMode;
     }
 
-    mapping(bytes19 addressPrefix => OwnerStorage ownerStorage) internal ownerLookup;
+    mapping(bytes19 addressPrefix => OwnerStorage) internal ownerLookup;
 
     mapping(bytes19 addressPrefix => mapping(address operator => uint256 operatorBitField)) internal operatorLookup;
 

--- a/src/EthereumVaultConnector.sol
+++ b/src/EthereumVaultConnector.sol
@@ -748,30 +748,25 @@ contract EthereumVaultConnector is Events, Errors, TransientStorage, IEVC {
         }
 
         address msgSender = _msgSender();
-        bool authenticated = false;
 
         // check if the caller is the owner of the account
         if (haveCommonOwnerInternal(account, msgSender)) {
             // if the owner is not registered, register it
             if (owner == address(0)) {
                 setAccountOwnerInternal(account, msgSender);
-                authenticated = true;
+                return msgSender;
             } else if (owner == msgSender) {
-                authenticated = true;
+                return msgSender;
             }
         }
 
         // if the caller is not the owner, check if it is an operator if operators are allowed
-        if (!authenticated && allowOperator) {
-            authenticated = isAccountOperatorAuthorizedInternal(account, msgSender);
+        if (allowOperator && isAccountOperatorAuthorizedInternal(account, msgSender)) {
+            return msgSender;
         }
 
         // must revert if neither the owner nor the operator were authenticated
-        if (!authenticated) {
-            revert EVC_NotAuthorized();
-        }
-
-        return msgSender;
+        revert EVC_NotAuthorized();
     }
 
     function callWithContextInternal(

--- a/src/EthereumVaultConnector.sol
+++ b/src/EthereumVaultConnector.sol
@@ -625,7 +625,7 @@ contract EthereumVaultConnector is Events, Errors, TransientStorage, IEVC {
                 callWithAuthenticationInternal(item.targetContract, item.onBehalfOfAccount, item.value, item.data);
         }
 
-        executionContext = contextCache.setChecksInProgress();
+        executionContext = contextCache.setChecksInProgress().setOnBehalfOfAccount(address(0));
 
         accountsStatusCheckResult = checkStatusAllWithResult(SetType.Account);
         vaultsStatusCheckResult = checkStatusAllWithResult(SetType.Vault);

--- a/src/EthereumVaultConnector.sol
+++ b/src/EthereumVaultConnector.sol
@@ -24,7 +24,7 @@ contract EthereumVaultConnector is Events, Errors, TransientStorage, IEVC {
     string public constant name = "Ethereum Vault Connector";
     string public constant version = "1";
 
-    uint256 internal constant ACCOUNT_ID_OFFSET = 8;
+    uint160 internal constant ACCOUNT_ID_OFFSET = 8;
     bytes32 internal constant HASHED_NAME = keccak256(bytes(name));
     bytes32 internal constant HASHED_VERSION = keccak256(bytes(version));
 

--- a/src/EthereumVaultConnector.sol
+++ b/src/EthereumVaultConnector.sol
@@ -355,7 +355,8 @@ contract EthereumVaultConnector is Events, Errors, TransientStorage, IEVC {
 
         // if the account and the caller have a common owner, the caller must be the owner. if the account and the
         // caller don't have a common owner, the caller must be an operator and the owner address is taken from the
-        // storage
+        // storage. the caller authentication above guarantees that the account owner is already registered hence
+        // non-zero
         address owner = haveCommonOwnerInternal(account, msgSender) ? msgSender : getAccountOwnerInternal(account);
 
         // if it's an operator calling, it can only act for itself and must not be able to change other operators status

--- a/src/EthereumVaultConnector.sol
+++ b/src/EthereumVaultConnector.sol
@@ -24,6 +24,7 @@ contract EthereumVaultConnector is Events, Errors, TransientStorage, IEVC {
     string public constant name = "Ethereum Vault Connector";
     string public constant version = "1";
 
+    uint256 internal constant ACCOUNT_ID_OFFSET = 8;
     bytes32 internal constant HASHED_NAME = keccak256(bytes(name));
     bytes32 internal constant HASHED_VERSION = keccak256(bytes(version));
 
@@ -108,7 +109,7 @@ contract EthereumVaultConnector is Events, Errors, TransientStorage, IEVC {
     modifier onlyOwner(bytes19 addressPrefix) {
         // calculate a phantom address from the address prefix which can be used as an input to the authenticateCaller()
         // function
-        address phantomAccount = address(uint160(uint152(addressPrefix)) << 8);
+        address phantomAccount = address(uint160(uint152(addressPrefix)) << ACCOUNT_ID_OFFSET);
         authenticateCaller({account: phantomAccount, allowOperator: false, checkLockdownMode: false});
 
         _;
@@ -333,7 +334,7 @@ contract EthereumVaultConnector is Events, Errors, TransientStorage, IEVC {
     function setOperator(bytes19 addressPrefix, address operator, uint256 operatorBitField) public payable virtual {
         // calculate a phantom address from the address prefix which can be used as an input to the authenticateCaller()
         // function
-        address phantomAccount = address(uint160(uint152(addressPrefix)) << 8);
+        address phantomAccount = address(uint160(uint152(addressPrefix)) << ACCOUNT_ID_OFFSET);
         address msgSender =
             authenticateCaller({account: phantomAccount, allowOperator: false, checkLockdownMode: false});
 

--- a/src/EthereumVaultConnector.sol
+++ b/src/EthereumVaultConnector.sol
@@ -912,7 +912,7 @@ contract EthereumVaultConnector is Events, Errors, TransientStorage, IEVC {
         for (uint256 i; i < length; ++i) {
             (address checkedAddress, bool isValid, bytes memory result) =
                 abi.decode(callbackResult[i], (address, bool, bytes));
-            checksResult[i] = StatusCheckResult(checkedAddress, isValid, result);
+            checksResult[i] = StatusCheckResult({checkedAddress: checkedAddress, isValid: isValid, result: result});
         }
     }
 

--- a/src/EthereumVaultConnector.sol
+++ b/src/EthereumVaultConnector.sol
@@ -91,7 +91,10 @@ contract EthereumVaultConnector is Events, Errors, TransientStorage, IEVC {
     }
 
     receive() external payable {
-        // only receives value, no need to do anything here
+        // only allows to receive value when checks are deferred
+        if (!executionContext.areChecksDeferred()) {
+            revert EVC_NotAuthorized();
+        }
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/ExecutionContext.sol
+++ b/src/ExecutionContext.sol
@@ -31,17 +31,10 @@ library ExecutionContext {
     uint256 internal constant SIMULATION_MASK = 0x00000000000000FF000000000000000000000000000000000000000000000000;
     uint256 internal constant STAMP_MASK = 0xFFFFFFFFFFFFFF00000000000000000000000000000000000000000000000000;
     uint256 internal constant STAMP_OFFSET = 200;
-    uint256 internal constant STAMP_DUMMY_VALUE = 1;
 
     // None of the functions below modifies the state. All the functions operate on the copy
     // of the execution context and return its modified value as a result. In order to update
     // one should use the result of the function call as a new execution context value.
-
-    function initialize(EC self) internal pure returns (EC result) {
-        // prepopulate the execution context storage slot to optimize gas consumption
-        // (it should never be cleared again thanks to the stamp)
-        result = EC.wrap(EC.unwrap(self) | (STAMP_DUMMY_VALUE << STAMP_OFFSET));
-    }
 
     function getOnBehalfOfAccount(EC self) internal pure returns (address result) {
         result = address(uint160(EC.unwrap(self) & ON_BEHALF_OF_ACCOUNT_MASK));

--- a/src/Set.sol
+++ b/src/Set.sol
@@ -28,7 +28,7 @@ struct SetStorage {
     /// @notice The stamp of the set.
     uint88 stamp;
     /// @notice The array of elements in the set. Stores the elements starting from index 1.
-    ElementStorage[2 ** 8] elements;
+    ElementStorage[2 ** 8 - 1] elements;
 }
 
 /// @title Set

--- a/src/Set.sol
+++ b/src/Set.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.19;
 
 /// @dev Represents the maximum number of elements that can be stored in the set.
 /// Must not exceed 255 due to the uint8 data type limit.
-uint8 constant MAX_ELEMENTS = 10;
+uint8 constant SET_MAX_ELEMENTS = 10;
 
 /// @title ElementStorage
 /// @notice This struct is used to store the value and stamp of an element.
@@ -32,13 +32,13 @@ struct SetStorage {
     /// @notice The stamp of the set.
     uint88 stamp;
     /// @notice The array of elements in the set. Stores the elements starting from index 1.
-    ElementStorage[MAX_ELEMENTS] elements;
+    ElementStorage[SET_MAX_ELEMENTS] elements;
 }
 
 /// @title Set
 /// @author Euler Labs (https://www.eulerlabs.com/)
 /// @notice This library provides functions for managing sets of addresses.
-/// @dev The maximum number of elements in the set is defined by the constant MAX_ELEMENTS.
+/// @dev The maximum number of elements in the set is defined by the constant SET_MAX_ELEMENTS.
 library Set {
     error TooManyElements();
     error InvalidIndex();
@@ -54,7 +54,7 @@ library Set {
     function initialize(SetStorage storage setStorage) internal {
         setStorage.stamp = DUMMY_STAMP;
 
-        for (uint256 i = EMPTY_ELEMENT_OFFSET; i < MAX_ELEMENTS; ++i) {
+        for (uint256 i = EMPTY_ELEMENT_OFFSET; i < SET_MAX_ELEMENTS; ++i) {
             setStorage.elements[i].stamp = DUMMY_STAMP;
         }
     }
@@ -85,7 +85,7 @@ library Set {
             if (setStorage.elements[i].value == element) return false;
         }
 
-        if (numElements == MAX_ELEMENTS) revert TooManyElements();
+        if (numElements == SET_MAX_ELEMENTS) revert TooManyElements();
 
         setStorage.elements[numElements].value = element;
 

--- a/src/Set.sol
+++ b/src/Set.sol
@@ -2,6 +2,10 @@
 
 pragma solidity ^0.8.19;
 
+/// @dev Represents the maximum number of elements that can be stored in the set.
+/// Must not exceed 255 due to the uint8 data type limit.
+uint8 constant MAX_ELEMENTS = 10;
+
 /// @title ElementStorage
 /// @notice This struct is used to store the value and stamp of an element.
 /// @dev The stamp field is used to keep the storage slot non-zero when the element is removed.
@@ -28,7 +32,7 @@ struct SetStorage {
     /// @notice The stamp of the set.
     uint88 stamp;
     /// @notice The array of elements in the set. Stores the elements starting from index 1.
-    ElementStorage[2 ** 8 - 1] elements;
+    ElementStorage[MAX_ELEMENTS] elements;
 }
 
 /// @title Set
@@ -39,7 +43,6 @@ library Set {
     error TooManyElements();
     error InvalidIndex();
 
-    uint8 internal constant MAX_ELEMENTS = 10; // must not exceed 255
     uint8 internal constant EMPTY_ELEMENT_OFFSET = 1; // must be 1
     uint8 internal constant DUMMY_STAMP = 1;
 

--- a/src/Set.sol
+++ b/src/Set.sol
@@ -132,19 +132,26 @@ library Set {
 
         // set numElements for every execution path to avoid SSTORE and bit masking when the element removed is
         // firstElement
+        ElementStorage storage lastElement = setStorage.elements[lastIndex];
         if (searchIndex != lastIndex) {
             if (searchIndex == 0) {
-                setStorage.firstElement = setStorage.elements[lastIndex].value;
+                setStorage.firstElement = lastElement.value;
                 setStorage.numElements = uint8(lastIndex);
+                setStorage.stamp = DUMMY_STAMP;
             } else {
-                setStorage.elements[searchIndex].value = setStorage.elements[lastIndex].value;
+                setStorage.elements[searchIndex].value = lastElement.value;
+
+                setStorage.firstElement = firstElement;
                 setStorage.numElements = uint8(lastIndex);
+                setStorage.stamp = DUMMY_STAMP;
             }
         } else {
+            setStorage.firstElement = firstElement;
             setStorage.numElements = uint8(lastIndex);
+            setStorage.stamp = DUMMY_STAMP;
         }
 
-        setStorage.elements[lastIndex].value = address(0);
+        lastElement.value = address(0);
 
         return true;
     }

--- a/src/TransientStorage.sol
+++ b/src/TransientStorage.sol
@@ -26,7 +26,7 @@ abstract contract TransientStorage {
     constructor() {
         // set the execution context to non-zero value to always keep the storage slot in non-zero state.
         // it allows for cheaper SSTOREs when the execution context is in its default state
-        executionContext = executionContext.initialize();
+        executionContext = EC.wrap(1 << ExecutionContext.STAMP_OFFSET);
 
         // there are two types of data that are stored using SetStorage type:
         // - the data that is transient in nature (accountStatusChecks and vaultStatusChecks)

--- a/src/interfaces/IEthereumVaultConnector.sol
+++ b/src/interfaces/IEthereumVaultConnector.sol
@@ -48,6 +48,8 @@ interface IEVC {
 
     /// @notice Returns an account on behalf of which the operation is being executed at the moment and whether the
     /// controllerToCheck is an enabled controller for that account.
+    /// @dev This function should only be used by external smart contracts if msg.sender is the EVC. Otherwise, the 
+    /// account address returned must not be trusted.
     /// @dev When checks in progress, on behalf of account is always address(0). When address is zero, the function
     /// reverts to protect the consumer from ever relying on the on behalf of account address which is in its default
     /// state.
@@ -162,7 +164,8 @@ interface IEVC {
     function setPermitDisabledMode(bytes19 addressPrefix, bool enabled) external payable;
 
     /// @notice Sets the nonce for a given address prefix and nonce namespace.
-    /// @dev This function can only be called by the owner of the address prefix. Each nonce namespace provides a 256 bit
+    /// @dev This function can only be called by the owner of the address prefix. Each nonce namespace provides a 256
+    /// bit
     /// nonce that has to be used sequentially. There's no requirement to use all the nonces for a given nonce namespace
     /// before moving to the next one which allows the use of permit messages in a non-sequential manner. To invalidate
     /// signed permit messages, set the nonce for a given nonce namespace accordingly. To invalidate all the permit
@@ -178,7 +181,8 @@ interface IEVC {
     /// @param addressPrefix The address prefix for which the bit field is being set.
     /// @param operator The address of the operator for which the bit field is being set. Cannot be the EVC address,
     /// zero address, or an address belonging to the same address prefix.
-    /// @param operatorBitField The new bit field for the given address prefix and operator. Reverts if the provided value
+    /// @param operatorBitField The new bit field for the given address prefix and operator. Reverts if the provided
+    /// value
     /// is equal to the currently stored value.
     function setOperator(bytes19 addressPrefix, address operator, uint256 operatorBitField) external payable;
 
@@ -238,7 +242,8 @@ interface IEVC {
     function reorderCollaterals(address account, uint8 index1, uint8 index2) external payable;
 
     /// @notice Returns an array of enabled controllers for an account.
-    /// @dev A controller is a vault that has been chosen for an account to have special control over the account's balances
+    /// @dev A controller is a vault that has been chosen for an account to have special control over the account's
+    /// balances
     /// in enabled collaterals vaults. A user can have multiple controllers during a call execution, but at most one
     /// can be selected when the account status check is performed.
     /// @param account The address of the account whose controllers are being queried.
@@ -296,7 +301,8 @@ interface IEVC {
     /// @notice Calls into a target contract as per data encoded.
     /// @dev This function defers the account and vault status checks (it's a checks-deferrable call). If the outermost
     /// call ends, the account and vault status checks are performed.
-    /// @dev This function can be used to interact with any contract while checks are deferred. If the target contract is
+    /// @dev This function can be used to interact with any contract while checks are deferred. If the target contract
+    /// is
     /// msg.sender, msg.sender is called back with the calldata provided and the context set up according to the
     /// account provided. If the target contract is not msg.sender, only the owner or the operator of the account
     /// provided can call this function.
@@ -321,7 +327,8 @@ interface IEVC {
     /// controller vault as per data encoded.
     /// @dev This function defers the account and vault status checks (it's a checks-deferrable call). If the outermost
     /// call ends, the account and vault status checks are performed.
-    /// @dev This function can be used to interact with any contract while checks are deferred as long as the contract is
+    /// @dev This function can be used to interact with any contract while checks are deferred as long as the contract
+    /// is
     /// enabled as a collateral of the account and the msg.sender is the only enabled controller of the account.
     /// @param targetCollateral The collateral address to be called.
     /// @param onBehalfOfAccount The address of the account for which it is checked whether msg.sender is authorized to

--- a/src/interfaces/IEthereumVaultConnector.sol
+++ b/src/interfaces/IEthereumVaultConnector.sol
@@ -165,11 +165,10 @@ interface IEVC {
 
     /// @notice Sets the nonce for a given address prefix and nonce namespace.
     /// @dev This function can only be called by the owner of the address prefix. Each nonce namespace provides a 256
-    /// bit
-    /// nonce that has to be used sequentially. There's no requirement to use all the nonces for a given nonce namespace
-    /// before moving to the next one which allows the use of permit messages in a non-sequential manner. To invalidate
-    /// signed permit messages, set the nonce for a given nonce namespace accordingly. To invalidate all the permit
-    /// messages for a given nonce namespace, set the nonce to type(uint).max.
+    /// bit nonce that has to be used sequentially. There's no requirement to use all the nonces for a given nonce
+    /// namespace before moving to the next one which allows the use of permit messages in a non-sequential manner. To
+    /// invalidate signed permit messages, set the nonce for a given nonce namespace accordingly. To invalidate all the
+    /// permit messages for a given nonce namespace, set the nonce to type(uint).max.
     /// @param addressPrefix The address prefix for which the nonce is being set.
     /// @param nonceNamespace The nonce namespace for which the nonce is being set.
     /// @param nonce The new nonce for the given address prefix and nonce namespace.

--- a/src/interfaces/IEthereumVaultConnector.sol
+++ b/src/interfaces/IEthereumVaultConnector.sol
@@ -48,7 +48,7 @@ interface IEVC {
 
     /// @notice Returns an account on behalf of which the operation is being executed at the moment and whether the
     /// controllerToCheck is an enabled controller for that account.
-    /// @dev This function should only be used by external smart contracts if msg.sender is the EVC. Otherwise, the 
+    /// @dev This function should only be used by external smart contracts if msg.sender is the EVC. Otherwise, the
     /// account address returned must not be trusted.
     /// @dev When checks in progress, on behalf of account is always address(0). When address is zero, the function
     /// reverts to protect the consumer from ever relying on the on behalf of account address which is in its default

--- a/src/interfaces/IEthereumVaultConnector.sol
+++ b/src/interfaces/IEthereumVaultConnector.sol
@@ -280,6 +280,8 @@ interface IEVC {
     /// @param signer The address signing the permit message (ECDSA) or verifying the permit message signature
     /// (ERC-1271). It's also the owner or the operator of all the accounts for which authentication will be needed
     /// during the execution of the arbitrary data call.
+    /// @param sender The address of the msg.sender which is expected to execute the data signed by the signer. If
+    /// address(0) is passed, the msg.sender is ignored.
     /// @param nonceNamespace The nonce namespace for which the nonce is being used.
     /// @param nonce The nonce for the given account and nonce namespace. A valid nonce value is considered to be the
     /// value currently stored and can take any value between 0 and type(uint256).max - 1.
@@ -290,6 +292,7 @@ interface IEVC {
     /// @param signature The signature of the data signed by the signer.
     function permit(
         address signer,
+        address sender,
         uint256 nonceNamespace,
         uint256 nonce,
         uint256 deadline,

--- a/src/interfaces/IVault.sol
+++ b/src/interfaces/IVault.sol
@@ -15,12 +15,16 @@ interface IVault {
     function disableController() external;
 
     /// @notice Checks the status of an account.
+    /// @dev This function must only revert if the account status is invalid. If this function reverts due to any other
+    /// reason, it may render the account unusable with possibly no way to recover funds.
     /// @param account The address of the account to be checked.
     /// @return magicValue Must return the bytes4 magic value 0xb168c58f (which is a selector of this function) when
     /// account status is valid, or revert otherwise.
     function checkAccountStatus(address account, address[] calldata collaterals) external returns (bytes4 magicValue);
 
     /// @notice Checks the status of the vault.
+    /// @dev This function must only revert if the vault status is invalid. If this function reverts due to any other
+    /// reason, it may render the account unusable with possibly no way to recover funds.
     /// @return magicValue Must return the bytes4 magic value 0x4b3d1223 (which is a selector of this function) when
     /// account status is valid, or revert otherwise.
     function checkVaultStatus() external returns (bytes4 magicValue);

--- a/src/interfaces/IVault.sol
+++ b/src/interfaces/IVault.sol
@@ -15,16 +15,16 @@ interface IVault {
     function disableController() external;
 
     /// @notice Checks the status of an account.
-    /// @dev This function must only revert if the account status is invalid. If this function reverts due to any other
-    /// reason, it may render the account unusable with possibly no way to recover funds.
+    /// @dev This function must only deliberately revert if the account status is invalid. If this function reverts due
+    /// to any other reason, it may render the account unusable with possibly no way to recover funds.
     /// @param account The address of the account to be checked.
     /// @return magicValue Must return the bytes4 magic value 0xb168c58f (which is a selector of this function) when
     /// account status is valid, or revert otherwise.
     function checkAccountStatus(address account, address[] calldata collaterals) external returns (bytes4 magicValue);
 
     /// @notice Checks the status of the vault.
-    /// @dev This function must only revert if the vault status is invalid. If this function reverts due to any other
-    /// reason, it may render the account unusable with possibly no way to recover funds.
+    /// @dev This function must only deliberately revert if the vault status is invalid. If this function reverts due to
+    /// any other reason, it may render some accounts unusable with possibly no way to recover funds.
     /// @return magicValue Must return the bytes4 magic value 0x4b3d1223 (which is a selector of this function) when
     /// account status is valid, or revert otherwise.
     function checkVaultStatus() external returns (bytes4 magicValue);

--- a/src/utils/EVCUtil.sol
+++ b/src/utils/EVCUtil.sol
@@ -29,11 +29,10 @@ abstract contract EVCUtil {
         if (msg.sender == address(evc)) {
             _;
         } else {
-            bytes32 _evcCallSelector = evc.call.selector;
             address _evc = address(evc);
 
             assembly {
-                mstore(0, _evcCallSelector) // EVC.call selector
+                mstore(0, 0x1f8b521500000000000000000000000000000000000000000000000000000000) // EVC.call selector
                 mstore(4, address()) // EVC.call 1st argument - address(this)
                 mstore(36, caller()) // EVC.call 2nd argument - msg.sender
                 mstore(68, callvalue()) // EVC.call 3rd argument - msg.value

--- a/src/utils/EVCUtil.sol
+++ b/src/utils/EVCUtil.sol
@@ -11,10 +11,13 @@ import "../interfaces/IEthereumVaultConnector.sol";
 abstract contract EVCUtil {
     IEVC internal immutable evc;
 
+    error EVC_InvalidAddress();
     error NotAuthorized();
     error ControllerDisabled();
 
     constructor(IEVC _evc) {
+        if (address(_evc) == address(0)) revert EVC_InvalidAddress();
+
         evc = _evc;
     }
 

--- a/src/utils/EVCUtil.sol
+++ b/src/utils/EVCUtil.sol
@@ -29,27 +29,23 @@ abstract contract EVCUtil {
         if (msg.sender == address(evc)) {
             _;
         } else {
-            bytes memory result = evc.call(address(this), msg.sender, 0, msg.data);
+            bytes32 _evcCallSelector = evc.call.selector;
+            address _evc = address(evc);
 
             assembly {
-                return(add(32, result), mload(result))
-            }
-        }
-    }
+                mstore(0, _evcCallSelector) // EVC.call selector
+                mstore(4, address()) // EVC.call 1st argument - address(this)
+                mstore(36, caller()) // EVC.call 2nd argument - msg.sender
+                mstore(68, callvalue()) // EVC.call 3rd argument - msg.value
+                mstore(100, 128) // EVC.call 4th argument - msg.data, offset to the start of encoding - 128 bytes
+                mstore(132, calldatasize()) // msg.data length
+                calldatacopy(164, 0, calldatasize()) // original calldata
+                let result := call(gas(), _evc, callvalue(), 0, add(164, calldatasize()), 0, 0)
 
-    /// @notice Ensures that the msg.sender is the EVC by using the EVC callback functionality if necessary.
-    /// @dev Optional to use for functions requiring account and vault status checks to enforce predictable behavior.
-    /// @dev If this modifier used in conjuction with any other modifier, it must appear as the first (outermost)
-    /// modifier of the function.
-    /// @dev This modifier is used for payable functions because it forwards the value to the EVC.
-    modifier callThroughEVCPayable() virtual {
-        if (msg.sender == address(evc)) {
-            _;
-        } else {
-            bytes memory result = evc.call{value: msg.value}(address(this), msg.sender, msg.value, msg.data);
-
-            assembly {
-                return(add(32, result), mload(result))
+                returndatacopy(0, 0, returndatasize())
+                switch result
+                case 0 { revert(0, returndatasize()) }
+                default { return(64, sub(returndatasize(), 64)) } // strip bytes encoding from call return
             }
         }
     }

--- a/test/evc/EthereumVaultConnectorScribble.sol
+++ b/test/evc/EthereumVaultConnectorScribble.sol
@@ -75,6 +75,7 @@ contract EthereumVaultConnectorScribble is EthereumVaultConnector {
     /// #if_succeeds "is non-reentrant" !old(executionContext.areChecksInProgress()) && !old(executionContext.isControlCollateralInProgress());
     function permit(
         address signer,
+        address sender,
         uint256 nonceNamespace,
         uint256 nonce,
         uint256 deadline,
@@ -82,7 +83,7 @@ contract EthereumVaultConnectorScribble is EthereumVaultConnector {
         bytes calldata data,
         bytes calldata signature
     ) public payable virtual override {
-        super.permit(signer, nonceNamespace, nonce, deadline, value, data, signature);
+        super.permit(signer, sender, nonceNamespace, nonce, deadline, value, data, signature);
     }
 
     /// #if_succeeds "is non-reentrant" !old(executionContext.areChecksInProgress()) && !old(executionContext.isControlCollateralInProgress());

--- a/test/gas/EVCGas.t.sol
+++ b/test/gas/EVCGas.t.sol
@@ -8,13 +8,14 @@ import "../../src/EthereumVaultConnector.sol";
 contract EVCHarness is EthereumVaultConnector {
     function permitHash(
         address signer,
+        address sender,
         uint256 nonceNamespace,
         uint256 nonce,
         uint256 deadline,
         uint256 value,
         bytes calldata data
     ) external view returns (bytes32) {
-        return getPermitHash(signer, nonceNamespace, nonce, deadline, value, data);
+        return getPermitHash(signer, sender, nonceNamespace, nonce, deadline, value, data);
     }
 
     function getIsValidERC1271Signature(
@@ -44,7 +45,7 @@ contract EVCGas is Test {
         uint256 value,
         bytes calldata data
     ) public view {
-        evc.permitHash(signer, nonceNamespace, nonce, deadline, value, data);
+        evc.permitHash(signer, address(this), nonceNamespace, nonce, deadline, value, data);
     }
 
     function testGas_haveCommonOwner(address a, address b) public view {

--- a/test/invariants/EthereumVaultConnector.t.sol
+++ b/test/invariants/EthereumVaultConnector.t.sol
@@ -220,7 +220,7 @@ contract EthereumVaultConnectorHandler is EthereumVaultConnectorScribble, Test {
     }
 
     function batch(BatchItem[] calldata items) public payable override {
-        if (items.length > Set.MAX_ELEMENTS) return;
+        if (items.length > MAX_ELEMENTS) return;
 
         for (uint256 i = 0; i < items.length; i++) {
             if (uint160(items[i].value) > type(uint128).max) return;
@@ -272,9 +272,9 @@ contract EthereumVaultConnectorHandler is EthereumVaultConnectorScribble, Test {
     }
 
     function exposeAccountCollaterals(address account) external view returns (uint8, address[] memory) {
-        address[] memory result = new address[](Set.MAX_ELEMENTS);
+        address[] memory result = new address[](MAX_ELEMENTS);
 
-        for (uint256 i = 0; i < Set.MAX_ELEMENTS; i++) {
+        for (uint256 i = 0; i < MAX_ELEMENTS; i++) {
             if (i == 0) {
                 result[i] = accountCollaterals[account].firstElement;
             } else {
@@ -285,9 +285,9 @@ contract EthereumVaultConnectorHandler is EthereumVaultConnectorScribble, Test {
     }
 
     function exposeAccountControllers(address account) external view returns (uint8, address[] memory) {
-        address[] memory result = new address[](Set.MAX_ELEMENTS);
+        address[] memory result = new address[](MAX_ELEMENTS);
 
-        for (uint256 i = 0; i < Set.MAX_ELEMENTS; i++) {
+        for (uint256 i = 0; i < MAX_ELEMENTS; i++) {
             if (i == 0) {
                 result[i] = accountControllers[account].firstElement;
             } else {
@@ -302,10 +302,10 @@ contract EthereumVaultConnectorHandler is EthereumVaultConnectorScribble, Test {
         view
         returns (uint8, address[] memory, uint8, address[] memory)
     {
-        address[] memory result1 = new address[](Set.MAX_ELEMENTS);
-        address[] memory result2 = new address[](Set.MAX_ELEMENTS);
+        address[] memory result1 = new address[](MAX_ELEMENTS);
+        address[] memory result2 = new address[](MAX_ELEMENTS);
 
-        for (uint256 i = 0; i < Set.MAX_ELEMENTS; i++) {
+        for (uint256 i = 0; i < MAX_ELEMENTS; i++) {
             if (i == 0) {
                 result1[i] = accountStatusChecks.firstElement;
                 result2[i] = vaultStatusChecks.firstElement;
@@ -379,7 +379,7 @@ contract EthereumVaultConnectorInvariants is Test {
             (uint8 accountCollateralsNumCollaterals, address[] memory accountCollateralsArray) =
                 evc.exposeAccountCollaterals(touchedAccounts[i]);
 
-            assertTrue(accountCollateralsNumCollaterals <= Set.MAX_ELEMENTS);
+            assertTrue(accountCollateralsNumCollaterals <= MAX_ELEMENTS);
             for (uint256 j = 0; j < accountCollateralsNumCollaterals; j++) {
                 assertTrue(accountCollateralsArray[j] != address(0));
             }

--- a/test/invariants/EthereumVaultConnector.t.sol
+++ b/test/invariants/EthereumVaultConnector.t.sol
@@ -201,6 +201,7 @@ contract EthereumVaultConnectorHandler is EthereumVaultConnectorScribble, Test {
 
     function permit(
         address signer,
+        address,
         uint256 nonceNamespace,
         uint256 nonce,
         uint256 deadline,
@@ -216,7 +217,7 @@ contract EthereumVaultConnectorHandler is EthereumVaultConnectorScribble, Test {
         deal(address(this), value);
         nonce = nonceLookup[getAddressPrefixInternal(signer)][nonceNamespace];
         deadline = block.timestamp;
-        super.permit(signer, nonceNamespace, nonce, deadline, value, data, signature);
+        super.permit(signer, msg.sender, nonceNamespace, nonce, deadline, value, data, signature);
     }
 
     function batch(BatchItem[] calldata items) public payable override {

--- a/test/invariants/EthereumVaultConnector.t.sol
+++ b/test/invariants/EthereumVaultConnector.t.sol
@@ -221,7 +221,7 @@ contract EthereumVaultConnectorHandler is EthereumVaultConnectorScribble, Test {
     }
 
     function batch(BatchItem[] calldata items) public payable override {
-        if (items.length > MAX_ELEMENTS) return;
+        if (items.length > SET_MAX_ELEMENTS) return;
 
         for (uint256 i = 0; i < items.length; i++) {
             if (uint160(items[i].value) > type(uint128).max) return;
@@ -273,9 +273,9 @@ contract EthereumVaultConnectorHandler is EthereumVaultConnectorScribble, Test {
     }
 
     function exposeAccountCollaterals(address account) external view returns (uint8, address[] memory) {
-        address[] memory result = new address[](MAX_ELEMENTS);
+        address[] memory result = new address[](SET_MAX_ELEMENTS);
 
-        for (uint256 i = 0; i < MAX_ELEMENTS; i++) {
+        for (uint256 i = 0; i < SET_MAX_ELEMENTS; i++) {
             if (i == 0) {
                 result[i] = accountCollaterals[account].firstElement;
             } else {
@@ -286,9 +286,9 @@ contract EthereumVaultConnectorHandler is EthereumVaultConnectorScribble, Test {
     }
 
     function exposeAccountControllers(address account) external view returns (uint8, address[] memory) {
-        address[] memory result = new address[](MAX_ELEMENTS);
+        address[] memory result = new address[](SET_MAX_ELEMENTS);
 
-        for (uint256 i = 0; i < MAX_ELEMENTS; i++) {
+        for (uint256 i = 0; i < SET_MAX_ELEMENTS; i++) {
             if (i == 0) {
                 result[i] = accountControllers[account].firstElement;
             } else {
@@ -303,10 +303,10 @@ contract EthereumVaultConnectorHandler is EthereumVaultConnectorScribble, Test {
         view
         returns (uint8, address[] memory, uint8, address[] memory)
     {
-        address[] memory result1 = new address[](MAX_ELEMENTS);
-        address[] memory result2 = new address[](MAX_ELEMENTS);
+        address[] memory result1 = new address[](SET_MAX_ELEMENTS);
+        address[] memory result2 = new address[](SET_MAX_ELEMENTS);
 
-        for (uint256 i = 0; i < MAX_ELEMENTS; i++) {
+        for (uint256 i = 0; i < SET_MAX_ELEMENTS; i++) {
             if (i == 0) {
                 result1[i] = accountStatusChecks.firstElement;
                 result2[i] = vaultStatusChecks.firstElement;
@@ -380,7 +380,7 @@ contract EthereumVaultConnectorInvariants is Test {
             (uint8 accountCollateralsNumCollaterals, address[] memory accountCollateralsArray) =
                 evc.exposeAccountCollaterals(touchedAccounts[i]);
 
-            assertTrue(accountCollateralsNumCollaterals <= MAX_ELEMENTS);
+            assertTrue(accountCollateralsNumCollaterals <= SET_MAX_ELEMENTS);
             for (uint256 j = 0; j < accountCollateralsNumCollaterals; j++) {
                 assertTrue(accountCollateralsArray[j] != address(0));
             }

--- a/test/unit/EVCUtil/EVCUtil.t.sol
+++ b/test/unit/EVCUtil/EVCUtil.t.sol
@@ -63,6 +63,11 @@ contract EVCUtilTest is Test {
         evcClient = new EVCClient(evc);
     }
 
+    function test_EVCUtilConstructor() external {
+        vm.expectRevert(EVCUtil.EVC_InvalidAddress.selector);
+        new EVCClient(IEVC(address(0)));
+    }
+
     function test_callThroughEVCUint(uint256 input) external {
         {
             // call directly

--- a/test/unit/EVCUtil/EVCUtil.t.sol
+++ b/test/unit/EVCUtil/EVCUtil.t.sol
@@ -17,7 +17,7 @@ contract EVCClient is EVCUtil {
         return param;
     }
 
-    function calledThroughEVCPayableUint(uint256 param) external payable callThroughEVCPayable returns (uint256) {
+    function calledThroughEVCPayableUint(uint256 param) external payable callThroughEVC returns (uint256) {
         require(msg.sender == address(evc), "Not EVC");
         return param;
     }
@@ -30,7 +30,7 @@ contract EVCClient is EVCUtil {
     function calledThroughEVCPayableBytes(bytes calldata param)
         external
         payable
-        callThroughEVCPayable
+        callThroughEVC
         returns (bytes memory)
     {
         require(msg.sender == address(evc), "Not EVC");

--- a/test/unit/EthereumVaultConnector/AccountAndVaultStatus.t.sol
+++ b/test/unit/EthereumVaultConnector/AccountAndVaultStatus.t.sol
@@ -20,7 +20,7 @@ contract AccountAndVaultStatusTest is Test {
         bytes memory seed,
         bool allStatusesValid
     ) external {
-        vm.assume(numberOfAddresses > 0 && numberOfAddresses <= Set.MAX_ELEMENTS);
+        vm.assume(numberOfAddresses > 0 && numberOfAddresses <= MAX_ELEMENTS);
 
         address[] memory accounts = new address[](numberOfAddresses);
         address[] memory controllers = new address[](numberOfAddresses);
@@ -84,7 +84,7 @@ contract AccountAndVaultStatusTest is Test {
     }
 
     function test_WhenDeferred_RequireAccountAndVaultStatusCheck(uint8 numberOfAddresses, bytes memory seed) external {
-        vm.assume(numberOfAddresses > 0 && numberOfAddresses <= Set.MAX_ELEMENTS);
+        vm.assume(numberOfAddresses > 0 && numberOfAddresses <= MAX_ELEMENTS);
 
         address[] memory accounts = new address[](numberOfAddresses);
         address[] memory controllers = new address[](numberOfAddresses);
@@ -132,7 +132,7 @@ contract AccountAndVaultStatusTest is Test {
         address[] calldata accounts
     ) external {
         vm.assume(index < accounts.length);
-        vm.assume(accounts.length > 0 && accounts.length <= Set.MAX_ELEMENTS);
+        vm.assume(accounts.length > 0 && accounts.length <= MAX_ELEMENTS);
 
         address vault = address(new Vault(evc));
 
@@ -151,7 +151,7 @@ contract AccountAndVaultStatusTest is Test {
         uint8 numberOfAddresses,
         bytes memory seed
     ) external {
-        vm.assume(numberOfAddresses > 0 && numberOfAddresses <= Set.MAX_ELEMENTS);
+        vm.assume(numberOfAddresses > 0 && numberOfAddresses <= MAX_ELEMENTS);
 
         address[] memory accounts = new address[](numberOfAddresses);
         address[] memory controllers = new address[](numberOfAddresses);

--- a/test/unit/EthereumVaultConnector/AccountAndVaultStatus.t.sol
+++ b/test/unit/EthereumVaultConnector/AccountAndVaultStatus.t.sol
@@ -20,7 +20,7 @@ contract AccountAndVaultStatusTest is Test {
         bytes memory seed,
         bool allStatusesValid
     ) external {
-        vm.assume(numberOfAddresses > 0 && numberOfAddresses <= MAX_ELEMENTS);
+        vm.assume(numberOfAddresses > 0 && numberOfAddresses <= SET_MAX_ELEMENTS);
 
         address[] memory accounts = new address[](numberOfAddresses);
         address[] memory controllers = new address[](numberOfAddresses);
@@ -84,7 +84,7 @@ contract AccountAndVaultStatusTest is Test {
     }
 
     function test_WhenDeferred_RequireAccountAndVaultStatusCheck(uint8 numberOfAddresses, bytes memory seed) external {
-        vm.assume(numberOfAddresses > 0 && numberOfAddresses <= MAX_ELEMENTS);
+        vm.assume(numberOfAddresses > 0 && numberOfAddresses <= SET_MAX_ELEMENTS);
 
         address[] memory accounts = new address[](numberOfAddresses);
         address[] memory controllers = new address[](numberOfAddresses);
@@ -132,7 +132,7 @@ contract AccountAndVaultStatusTest is Test {
         address[] calldata accounts
     ) external {
         vm.assume(index < accounts.length);
-        vm.assume(accounts.length > 0 && accounts.length <= MAX_ELEMENTS);
+        vm.assume(accounts.length > 0 && accounts.length <= SET_MAX_ELEMENTS);
 
         address vault = address(new Vault(evc));
 
@@ -151,7 +151,7 @@ contract AccountAndVaultStatusTest is Test {
         uint8 numberOfAddresses,
         bytes memory seed
     ) external {
-        vm.assume(numberOfAddresses > 0 && numberOfAddresses <= MAX_ELEMENTS);
+        vm.assume(numberOfAddresses > 0 && numberOfAddresses <= SET_MAX_ELEMENTS);
 
         address[] memory accounts = new address[](numberOfAddresses);
         address[] memory controllers = new address[](numberOfAddresses);

--- a/test/unit/EthereumVaultConnector/AccountStatus.t.sol
+++ b/test/unit/EthereumVaultConnector/AccountStatus.t.sol
@@ -19,7 +19,7 @@ contract AccountStatusTest is Test {
         bytes memory seed,
         bool allStatusesValid
     ) external {
-        vm.assume(numberOfAccounts > 0 && numberOfAccounts <= MAX_ELEMENTS);
+        vm.assume(numberOfAccounts > 0 && numberOfAccounts <= SET_MAX_ELEMENTS);
 
         for (uint256 i = 0; i < numberOfAccounts; i++) {
             address account = address(uint160(uint256(keccak256(abi.encode(i, seed)))));
@@ -54,7 +54,7 @@ contract AccountStatusTest is Test {
     }
 
     function test_WhenDeferred_RequireAccountStatusCheck(uint8 numberOfAccounts, bytes memory seed) external {
-        vm.assume(numberOfAccounts > 0 && numberOfAccounts <= MAX_ELEMENTS);
+        vm.assume(numberOfAccounts > 0 && numberOfAccounts <= SET_MAX_ELEMENTS);
 
         for (uint256 i = 0; i < numberOfAccounts; i++) {
             evc.setChecksDeferred(false);
@@ -90,7 +90,7 @@ contract AccountStatusTest is Test {
     }
 
     function test_AcquireChecksLock_RequireAccountStatusChecks(uint8 numberOfAccounts, bytes memory seed) external {
-        vm.assume(numberOfAccounts > 0 && numberOfAccounts <= MAX_ELEMENTS);
+        vm.assume(numberOfAccounts > 0 && numberOfAccounts <= SET_MAX_ELEMENTS);
 
         for (uint256 i = 0; i < numberOfAccounts; i++) {
             address account = address(uint160(uint256(keccak256(abi.encode(i, seed)))));
@@ -108,7 +108,7 @@ contract AccountStatusTest is Test {
     }
 
     function test_ForgiveAccountStatusCheck(uint8 numberOfAccounts, bytes memory seed) external {
-        vm.assume(numberOfAccounts > 0 && numberOfAccounts <= MAX_ELEMENTS);
+        vm.assume(numberOfAccounts > 0 && numberOfAccounts <= SET_MAX_ELEMENTS);
 
         address[] memory accounts = new address[](numberOfAccounts);
         for (uint256 i = 0; i < numberOfAccounts; i++) {
@@ -171,7 +171,7 @@ contract AccountStatusTest is Test {
         uint8 numberOfAccounts,
         bytes memory seed
     ) external {
-        vm.assume(numberOfAccounts > 0 && numberOfAccounts <= MAX_ELEMENTS);
+        vm.assume(numberOfAccounts > 0 && numberOfAccounts <= SET_MAX_ELEMENTS);
 
         for (uint256 i = 0; i < numberOfAccounts; i++) {
             address account = address(uint160(uint256(keccak256(abi.encode(i, seed)))));
@@ -195,7 +195,7 @@ contract AccountStatusTest is Test {
         uint8 numberOfAccounts,
         bytes memory seed
     ) external {
-        vm.assume(numberOfAccounts > 0 && numberOfAccounts <= MAX_ELEMENTS);
+        vm.assume(numberOfAccounts > 0 && numberOfAccounts <= SET_MAX_ELEMENTS);
         address controller_1 = address(new Vault(evc));
         address controller_2 = address(new Vault(evc));
 
@@ -224,7 +224,7 @@ contract AccountStatusTest is Test {
         uint8 numberOfAccounts,
         bytes memory seed
     ) external {
-        vm.assume(numberOfAccounts > 0 && numberOfAccounts <= MAX_ELEMENTS);
+        vm.assume(numberOfAccounts > 0 && numberOfAccounts <= SET_MAX_ELEMENTS);
 
         address controller = address(new Vault(evc));
         for (uint256 i = 0; i < numberOfAccounts; i++) {

--- a/test/unit/EthereumVaultConnector/AccountStatus.t.sol
+++ b/test/unit/EthereumVaultConnector/AccountStatus.t.sol
@@ -19,7 +19,7 @@ contract AccountStatusTest is Test {
         bytes memory seed,
         bool allStatusesValid
     ) external {
-        vm.assume(numberOfAccounts > 0 && numberOfAccounts <= Set.MAX_ELEMENTS);
+        vm.assume(numberOfAccounts > 0 && numberOfAccounts <= MAX_ELEMENTS);
 
         for (uint256 i = 0; i < numberOfAccounts; i++) {
             address account = address(uint160(uint256(keccak256(abi.encode(i, seed)))));
@@ -54,7 +54,7 @@ contract AccountStatusTest is Test {
     }
 
     function test_WhenDeferred_RequireAccountStatusCheck(uint8 numberOfAccounts, bytes memory seed) external {
-        vm.assume(numberOfAccounts > 0 && numberOfAccounts <= Set.MAX_ELEMENTS);
+        vm.assume(numberOfAccounts > 0 && numberOfAccounts <= MAX_ELEMENTS);
 
         for (uint256 i = 0; i < numberOfAccounts; i++) {
             evc.setChecksDeferred(false);
@@ -90,7 +90,7 @@ contract AccountStatusTest is Test {
     }
 
     function test_AcquireChecksLock_RequireAccountStatusChecks(uint8 numberOfAccounts, bytes memory seed) external {
-        vm.assume(numberOfAccounts > 0 && numberOfAccounts <= Set.MAX_ELEMENTS);
+        vm.assume(numberOfAccounts > 0 && numberOfAccounts <= MAX_ELEMENTS);
 
         for (uint256 i = 0; i < numberOfAccounts; i++) {
             address account = address(uint160(uint256(keccak256(abi.encode(i, seed)))));
@@ -108,7 +108,7 @@ contract AccountStatusTest is Test {
     }
 
     function test_ForgiveAccountStatusCheck(uint8 numberOfAccounts, bytes memory seed) external {
-        vm.assume(numberOfAccounts > 0 && numberOfAccounts <= Set.MAX_ELEMENTS);
+        vm.assume(numberOfAccounts > 0 && numberOfAccounts <= MAX_ELEMENTS);
 
         address[] memory accounts = new address[](numberOfAccounts);
         for (uint256 i = 0; i < numberOfAccounts; i++) {
@@ -171,7 +171,7 @@ contract AccountStatusTest is Test {
         uint8 numberOfAccounts,
         bytes memory seed
     ) external {
-        vm.assume(numberOfAccounts > 0 && numberOfAccounts <= Set.MAX_ELEMENTS);
+        vm.assume(numberOfAccounts > 0 && numberOfAccounts <= MAX_ELEMENTS);
 
         for (uint256 i = 0; i < numberOfAccounts; i++) {
             address account = address(uint160(uint256(keccak256(abi.encode(i, seed)))));
@@ -195,7 +195,7 @@ contract AccountStatusTest is Test {
         uint8 numberOfAccounts,
         bytes memory seed
     ) external {
-        vm.assume(numberOfAccounts > 0 && numberOfAccounts <= Set.MAX_ELEMENTS);
+        vm.assume(numberOfAccounts > 0 && numberOfAccounts <= MAX_ELEMENTS);
         address controller_1 = address(new Vault(evc));
         address controller_2 = address(new Vault(evc));
 
@@ -224,7 +224,7 @@ contract AccountStatusTest is Test {
         uint8 numberOfAccounts,
         bytes memory seed
     ) external {
-        vm.assume(numberOfAccounts > 0 && numberOfAccounts <= Set.MAX_ELEMENTS);
+        vm.assume(numberOfAccounts > 0 && numberOfAccounts <= MAX_ELEMENTS);
 
         address controller = address(new Vault(evc));
         for (uint256 i = 0; i < numberOfAccounts; i++) {

--- a/test/unit/EthereumVaultConnector/CollateralsManagement.t.sol
+++ b/test/unit/EthereumVaultConnector/CollateralsManagement.t.sol
@@ -60,7 +60,7 @@ contract CollateralsManagementTest is Test {
         setUp();
 
         vm.assume(alice != address(0) && alice != address(evc));
-        vm.assume(numberOfVaults > 0 && numberOfVaults <= Set.MAX_ELEMENTS);
+        vm.assume(numberOfVaults > 0 && numberOfVaults <= MAX_ELEMENTS);
         vm.assume(seed > 1000);
 
         address account = address(uint160(uint160(alice) ^ subAccountId));

--- a/test/unit/EthereumVaultConnector/CollateralsManagement.t.sol
+++ b/test/unit/EthereumVaultConnector/CollateralsManagement.t.sol
@@ -60,7 +60,7 @@ contract CollateralsManagementTest is Test {
         setUp();
 
         vm.assume(alice != address(0) && alice != address(evc));
-        vm.assume(numberOfVaults > 0 && numberOfVaults <= MAX_ELEMENTS);
+        vm.assume(numberOfVaults > 0 && numberOfVaults <= SET_MAX_ELEMENTS);
         vm.assume(seed > 1000);
 
         address account = address(uint160(uint160(alice) ^ subAccountId));

--- a/test/unit/EthereumVaultConnector/IsAccountStatusCheckDeferred.t.sol
+++ b/test/unit/EthereumVaultConnector/IsAccountStatusCheckDeferred.t.sol
@@ -13,7 +13,7 @@ contract IsAccountStatusCheckDeferredTest is Test {
     }
 
     function test_IsAccountStatusCheckDeferred(uint8 numberOfAccounts, bytes memory seed) external {
-        vm.assume(numberOfAccounts <= MAX_ELEMENTS);
+        vm.assume(numberOfAccounts <= SET_MAX_ELEMENTS);
 
         for (uint256 i = 0; i < numberOfAccounts; ++i) {
             evc.setChecksDeferred(false);

--- a/test/unit/EthereumVaultConnector/IsAccountStatusCheckDeferred.t.sol
+++ b/test/unit/EthereumVaultConnector/IsAccountStatusCheckDeferred.t.sol
@@ -13,7 +13,7 @@ contract IsAccountStatusCheckDeferredTest is Test {
     }
 
     function test_IsAccountStatusCheckDeferred(uint8 numberOfAccounts, bytes memory seed) external {
-        vm.assume(numberOfAccounts <= Set.MAX_ELEMENTS);
+        vm.assume(numberOfAccounts <= MAX_ELEMENTS);
 
         for (uint256 i = 0; i < numberOfAccounts; ++i) {
             evc.setChecksDeferred(false);

--- a/test/unit/EthereumVaultConnector/IsVaultStatusCheckDeferred.t.sol
+++ b/test/unit/EthereumVaultConnector/IsVaultStatusCheckDeferred.t.sol
@@ -13,7 +13,7 @@ contract IsVaultStatusCheckDeferredTest is Test {
     }
 
     function test_IsVaultStatusCheckDeferred(uint8 numberOfVaults) external {
-        vm.assume(numberOfVaults <= MAX_ELEMENTS);
+        vm.assume(numberOfVaults <= SET_MAX_ELEMENTS);
 
         for (uint256 i = 0; i < numberOfVaults; ++i) {
             evc.setChecksDeferred(false);

--- a/test/unit/EthereumVaultConnector/IsVaultStatusCheckDeferred.t.sol
+++ b/test/unit/EthereumVaultConnector/IsVaultStatusCheckDeferred.t.sol
@@ -13,7 +13,7 @@ contract IsVaultStatusCheckDeferredTest is Test {
     }
 
     function test_IsVaultStatusCheckDeferred(uint8 numberOfVaults) external {
-        vm.assume(numberOfVaults <= Set.MAX_ELEMENTS);
+        vm.assume(numberOfVaults <= MAX_ELEMENTS);
 
         for (uint256 i = 0; i < numberOfVaults; ++i) {
             evc.setChecksDeferred(false);

--- a/test/unit/EthereumVaultConnector/Receive.t.sol
+++ b/test/unit/EthereumVaultConnector/Receive.t.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+pragma solidity ^0.8.19;
+
+import "forge-std/Test.sol";
+import "../../evc/EthereumVaultConnectorHarness.sol";
+
+contract ReceiveTest is Test {
+    EthereumVaultConnectorHarness internal evc;
+
+    function setUp() public {
+        evc = new EthereumVaultConnectorHarness();
+    }
+
+    function test_Receive(uint64 value) external {
+        vm.assume(value > 0);
+        vm.deal(address(this), 2 * uint256(value));
+
+        // succeds when checks are not deferred
+        address(evc).call{value: value}("");
+
+        evc.setChecksDeferred(true);
+        vm.expectRevert(Errors.EVC_NotAuthorized.selector);
+        address(evc).call{value: value}("");
+    }
+}

--- a/test/unit/EthereumVaultConnector/SetLockdownMode.t.sol
+++ b/test/unit/EthereumVaultConnector/SetLockdownMode.t.sol
@@ -75,7 +75,7 @@ contract SetLockdownModeTest is Test {
         vm.assume(alice != address(0) && alice != address(evc) && !evc.haveCommonOwner(alice, operator));
         vm.assume(
             vault != address(0) && vault != address(evc) && vault != address(this) && vault != alice
-                && vault != operator
+                && vault != operator && !evc.haveCommonOwner(vault, address(0)) && vault.code.length == 0
         );
         vm.assume(operator != address(0) && operator != address(evc));
 

--- a/test/unit/EthereumVaultConnector/SetLockdownMode.t.sol
+++ b/test/unit/EthereumVaultConnector/SetLockdownMode.t.sol
@@ -73,7 +73,10 @@ contract SetLockdownModeTest is Test {
 
     function test_Integration_SetLockdownMode(address alice, address vault, address operator) public {
         vm.assume(alice != address(0) && alice != address(evc) && !evc.haveCommonOwner(alice, operator));
-        vm.assume(vault != address(0) && vault != address(evc) && vault != address(this) && vault != alice && vault != operator);
+        vm.assume(
+            vault != address(0) && vault != address(evc) && vault != address(this) && vault != alice
+                && vault != operator
+        );
         vm.assume(operator != address(0) && operator != address(evc));
 
         bytes19 addressPrefix = evc.getAddressPrefix(alice);

--- a/test/unit/EthereumVaultConnector/SetPermitDisabledMode.t.sol
+++ b/test/unit/EthereumVaultConnector/SetPermitDisabledMode.t.sol
@@ -73,7 +73,10 @@ contract SetPermitDisabledModeTest is Test {
 
     function test_Integration_SetPermitDisabledMode(address alice, address vault, address operator) public {
         vm.assume(alice != address(0) && alice != address(evc) && !evc.haveCommonOwner(alice, operator));
-        vm.assume(vault != address(0) && vault != address(evc) && vault != address(this) && vault != alice && vault != operator);
+        vm.assume(
+            vault != address(0) && vault != address(evc) && vault != address(this) && vault != alice
+                && vault != operator
+        );
         vm.assume(operator != address(0) && operator != address(evc));
 
         bytes19 addressPrefix = evc.getAddressPrefix(alice);

--- a/test/unit/EthereumVaultConnector/VaultStatus.t.sol
+++ b/test/unit/EthereumVaultConnector/VaultStatus.t.sol
@@ -15,7 +15,7 @@ contract VaultStatusTest is Test {
     }
 
     function test_RequireVaultStatusCheck(uint8 vaultsNumber, bool allStatusesValid) external {
-        vm.assume(vaultsNumber > 0 && vaultsNumber <= MAX_ELEMENTS);
+        vm.assume(vaultsNumber > 0 && vaultsNumber <= SET_MAX_ELEMENTS);
 
         for (uint256 i = 0; i < vaultsNumber; i++) {
             address vault = address(new Vault(evc));
@@ -43,7 +43,7 @@ contract VaultStatusTest is Test {
     }
 
     function test_WhenDeferred_RequireVaultStatusCheck(uint8 vaultsNumber, bool allStatusesValid) external {
-        vm.assume(vaultsNumber > 0 && vaultsNumber <= MAX_ELEMENTS);
+        vm.assume(vaultsNumber > 0 && vaultsNumber <= SET_MAX_ELEMENTS);
 
         for (uint256 i = 0; i < vaultsNumber; i++) {
             address vault = address(new Vault(evc));
@@ -77,7 +77,7 @@ contract VaultStatusTest is Test {
 
     function test_RevertIfChecksReentrancy_RequireVaultStatusCheck(uint8 index, uint8 vaultsNumber) external {
         vm.assume(index < vaultsNumber);
-        vm.assume(vaultsNumber > 0 && vaultsNumber <= MAX_ELEMENTS);
+        vm.assume(vaultsNumber > 0 && vaultsNumber <= SET_MAX_ELEMENTS);
 
         address[] memory vaults = new address[](vaultsNumber);
         for (uint256 i = 0; i < vaultsNumber; i++) {
@@ -96,7 +96,7 @@ contract VaultStatusTest is Test {
     }
 
     function test_AcquireChecksLock_RequireVaultStatusChecks(uint8 numberOfVaults) external {
-        vm.assume(numberOfVaults > 0 && numberOfVaults <= MAX_ELEMENTS);
+        vm.assume(numberOfVaults > 0 && numberOfVaults <= SET_MAX_ELEMENTS);
 
         address[] memory vaults = new address[](numberOfVaults);
         for (uint256 i = 0; i < numberOfVaults; i++) {
@@ -112,7 +112,7 @@ contract VaultStatusTest is Test {
     }
 
     function test_ForgiveVaultStatusCheck(uint8 vaultsNumber) external {
-        vm.assume(vaultsNumber > 0 && vaultsNumber <= MAX_ELEMENTS);
+        vm.assume(vaultsNumber > 0 && vaultsNumber <= SET_MAX_ELEMENTS);
 
         for (uint256 i = 0; i < vaultsNumber; i++) {
             address vault = address(new Vault(evc));

--- a/test/unit/EthereumVaultConnector/VaultStatus.t.sol
+++ b/test/unit/EthereumVaultConnector/VaultStatus.t.sol
@@ -15,7 +15,7 @@ contract VaultStatusTest is Test {
     }
 
     function test_RequireVaultStatusCheck(uint8 vaultsNumber, bool allStatusesValid) external {
-        vm.assume(vaultsNumber > 0 && vaultsNumber <= Set.MAX_ELEMENTS);
+        vm.assume(vaultsNumber > 0 && vaultsNumber <= MAX_ELEMENTS);
 
         for (uint256 i = 0; i < vaultsNumber; i++) {
             address vault = address(new Vault(evc));
@@ -43,7 +43,7 @@ contract VaultStatusTest is Test {
     }
 
     function test_WhenDeferred_RequireVaultStatusCheck(uint8 vaultsNumber, bool allStatusesValid) external {
-        vm.assume(vaultsNumber > 0 && vaultsNumber <= Set.MAX_ELEMENTS);
+        vm.assume(vaultsNumber > 0 && vaultsNumber <= MAX_ELEMENTS);
 
         for (uint256 i = 0; i < vaultsNumber; i++) {
             address vault = address(new Vault(evc));
@@ -77,7 +77,7 @@ contract VaultStatusTest is Test {
 
     function test_RevertIfChecksReentrancy_RequireVaultStatusCheck(uint8 index, uint8 vaultsNumber) external {
         vm.assume(index < vaultsNumber);
-        vm.assume(vaultsNumber > 0 && vaultsNumber <= Set.MAX_ELEMENTS);
+        vm.assume(vaultsNumber > 0 && vaultsNumber <= MAX_ELEMENTS);
 
         address[] memory vaults = new address[](vaultsNumber);
         for (uint256 i = 0; i < vaultsNumber; i++) {
@@ -96,7 +96,7 @@ contract VaultStatusTest is Test {
     }
 
     function test_AcquireChecksLock_RequireVaultStatusChecks(uint8 numberOfVaults) external {
-        vm.assume(numberOfVaults > 0 && numberOfVaults <= Set.MAX_ELEMENTS);
+        vm.assume(numberOfVaults > 0 && numberOfVaults <= MAX_ELEMENTS);
 
         address[] memory vaults = new address[](numberOfVaults);
         for (uint256 i = 0; i < numberOfVaults; i++) {
@@ -112,7 +112,7 @@ contract VaultStatusTest is Test {
     }
 
     function test_ForgiveVaultStatusCheck(uint8 vaultsNumber) external {
-        vm.assume(vaultsNumber > 0 && vaultsNumber <= Set.MAX_ELEMENTS);
+        vm.assume(vaultsNumber > 0 && vaultsNumber <= MAX_ELEMENTS);
 
         for (uint256 i = 0; i < vaultsNumber; i++) {
             address vault = address(new Vault(evc));

--- a/test/unit/Set/Set.t.sol
+++ b/test/unit/Set/Set.t.sol
@@ -51,7 +51,7 @@ contract SetTest is Test {
 
         // count added elements not to exceed the limit
         uint256 expectedNumElements;
-        for (uint256 i = 0; i < elements.length && expectedNumElements < MAX_ELEMENTS; ++i) {
+        for (uint256 i = 0; i < elements.length && expectedNumElements < SET_MAX_ELEMENTS; ++i) {
             if (setStorage.insert(elements[i])) ++expectedNumElements;
         }
 
@@ -109,7 +109,7 @@ contract SetTest is Test {
         seed = bound(seed, 101, type(uint256).max);
         delete setStorage;
 
-        for (uint256 i = 0; i < MAX_ELEMENTS; ++i) {
+        for (uint256 i = 0; i < SET_MAX_ELEMENTS; ++i) {
             assertEq(setStorage.insert(address(uint160(uint256(bytes32(keccak256(abi.encode(seed, i))))))), true);
         }
 
@@ -152,7 +152,7 @@ contract SetTest is Test {
     }
 
     function test_ContainsMaxElements_Insert() public {
-        for (uint256 i = 0; i < MAX_ELEMENTS; i++) {
+        for (uint256 i = 0; i < SET_MAX_ELEMENTS; i++) {
             address e = address(uint160(uint256(i)));
             address eNext = address(uint160(uint256(i + 1)));
             assertTrue(setStorage.insert(e));
@@ -160,11 +160,11 @@ contract SetTest is Test {
             assertFalse(setStorage.contains(eNext));
         }
 
-        assertEq(setStorage.numElements, MAX_ELEMENTS);
+        assertEq(setStorage.numElements, SET_MAX_ELEMENTS);
     }
 
     function test_Reorder(uint8 numberOfElements, address firstElement, uint8 index1, uint8 index2) public {
-        numberOfElements = uint8(bound(numberOfElements, 2, MAX_ELEMENTS));
+        numberOfElements = uint8(bound(numberOfElements, 2, SET_MAX_ELEMENTS));
         index1 = uint8(bound(index1, 0, numberOfElements - 2));
         index2 = uint8(bound(index2, index1 + 1, numberOfElements - 1));
 
@@ -193,7 +193,7 @@ contract SetTest is Test {
         uint8 index1,
         uint8 index2
     ) public {
-        numberOfElements = uint8(bound(numberOfElements, 2, MAX_ELEMENTS));
+        numberOfElements = uint8(bound(numberOfElements, 2, SET_MAX_ELEMENTS));
 
         for (uint8 i = 0; i < numberOfElements; ++i) {
             setStorage.insert(address(uint160(uint256(keccak256(abi.encode(i, firstElement))))));
@@ -259,7 +259,7 @@ contract SetTest is Test {
     }
 
     function test_ForEachAndClear(uint8 numberOfElements, address firstElement) public {
-        numberOfElements = uint8(bound(numberOfElements, 2, MAX_ELEMENTS));
+        numberOfElements = uint8(bound(numberOfElements, 2, SET_MAX_ELEMENTS));
 
         for (uint8 i = 0; i < numberOfElements; ++i) {
             address element = address(uint160(uint256(keccak256(abi.encode(i, firstElement)))));
@@ -273,13 +273,13 @@ contract SetTest is Test {
         assertEq(setStorage.numElements, 0);
         assertEq(setStorage.firstElement, address(0));
 
-        for (uint8 i = 0; i < MAX_ELEMENTS; ++i) {
+        for (uint8 i = 0; i < SET_MAX_ELEMENTS; ++i) {
             assertEq(setStorage.elements[i].value, address(0));
         }
     }
 
     function test_ForEachAndClearWithResult(uint8 numberOfElements, address firstElement) public {
-        numberOfElements = uint8(bound(numberOfElements, 2, MAX_ELEMENTS));
+        numberOfElements = uint8(bound(numberOfElements, 2, SET_MAX_ELEMENTS));
 
         for (uint8 i = 0; i < numberOfElements; ++i) {
             address element = address(uint160(uint256(keccak256(abi.encode(i, firstElement)))));
@@ -294,7 +294,7 @@ contract SetTest is Test {
         assertEq(setStorage.numElements, 0);
         assertEq(setStorage.firstElement, address(0));
 
-        for (uint8 i = 0; i < MAX_ELEMENTS; ++i) {
+        for (uint8 i = 0; i < SET_MAX_ELEMENTS; ++i) {
             assertEq(setStorage.elements[i].value, address(0));
         }
 

--- a/test/unit/Set/Set.t.sol
+++ b/test/unit/Set/Set.t.sol
@@ -51,7 +51,7 @@ contract SetTest is Test {
 
         // count added elements not to exceed the limit
         uint256 expectedNumElements;
-        for (uint256 i = 0; i < elements.length && expectedNumElements < Set.MAX_ELEMENTS; ++i) {
+        for (uint256 i = 0; i < elements.length && expectedNumElements < MAX_ELEMENTS; ++i) {
             if (setStorage.insert(elements[i])) ++expectedNumElements;
         }
 
@@ -109,7 +109,7 @@ contract SetTest is Test {
         seed = bound(seed, 101, type(uint256).max);
         delete setStorage;
 
-        for (uint256 i = 0; i < Set.MAX_ELEMENTS; ++i) {
+        for (uint256 i = 0; i < MAX_ELEMENTS; ++i) {
             assertEq(setStorage.insert(address(uint160(uint256(bytes32(keccak256(abi.encode(seed, i))))))), true);
         }
 
@@ -152,7 +152,7 @@ contract SetTest is Test {
     }
 
     function test_ContainsMaxElements_Insert() public {
-        for (uint256 i = 0; i < Set.MAX_ELEMENTS; i++) {
+        for (uint256 i = 0; i < MAX_ELEMENTS; i++) {
             address e = address(uint160(uint256(i)));
             address eNext = address(uint160(uint256(i + 1)));
             assertTrue(setStorage.insert(e));
@@ -160,11 +160,11 @@ contract SetTest is Test {
             assertFalse(setStorage.contains(eNext));
         }
 
-        assertEq(setStorage.numElements, Set.MAX_ELEMENTS);
+        assertEq(setStorage.numElements, MAX_ELEMENTS);
     }
 
     function test_Reorder(uint8 numberOfElements, address firstElement, uint8 index1, uint8 index2) public {
-        numberOfElements = uint8(bound(numberOfElements, 2, Set.MAX_ELEMENTS));
+        numberOfElements = uint8(bound(numberOfElements, 2, MAX_ELEMENTS));
         index1 = uint8(bound(index1, 0, numberOfElements - 2));
         index2 = uint8(bound(index2, index1 + 1, numberOfElements - 1));
 
@@ -193,7 +193,7 @@ contract SetTest is Test {
         uint8 index1,
         uint8 index2
     ) public {
-        numberOfElements = uint8(bound(numberOfElements, 2, Set.MAX_ELEMENTS));
+        numberOfElements = uint8(bound(numberOfElements, 2, MAX_ELEMENTS));
 
         for (uint8 i = 0; i < numberOfElements; ++i) {
             setStorage.insert(address(uint160(uint256(keccak256(abi.encode(i, firstElement))))));
@@ -259,7 +259,7 @@ contract SetTest is Test {
     }
 
     function test_ForEachAndClear(uint8 numberOfElements, address firstElement) public {
-        numberOfElements = uint8(bound(numberOfElements, 2, Set.MAX_ELEMENTS));
+        numberOfElements = uint8(bound(numberOfElements, 2, MAX_ELEMENTS));
 
         for (uint8 i = 0; i < numberOfElements; ++i) {
             address element = address(uint160(uint256(keccak256(abi.encode(i, firstElement)))));
@@ -273,13 +273,13 @@ contract SetTest is Test {
         assertEq(setStorage.numElements, 0);
         assertEq(setStorage.firstElement, address(0));
 
-        for (uint8 i = 0; i < Set.MAX_ELEMENTS; ++i) {
+        for (uint8 i = 0; i < MAX_ELEMENTS; ++i) {
             assertEq(setStorage.elements[i].value, address(0));
         }
     }
 
     function test_ForEachAndClearWithResult(uint8 numberOfElements, address firstElement) public {
-        numberOfElements = uint8(bound(numberOfElements, 2, Set.MAX_ELEMENTS));
+        numberOfElements = uint8(bound(numberOfElements, 2, MAX_ELEMENTS));
 
         for (uint8 i = 0; i < numberOfElements; ++i) {
             address element = address(uint160(uint256(keccak256(abi.encode(i, firstElement)))));
@@ -294,7 +294,7 @@ contract SetTest is Test {
         assertEq(setStorage.numElements, 0);
         assertEq(setStorage.firstElement, address(0));
 
-        for (uint8 i = 0; i < Set.MAX_ELEMENTS; ++i) {
+        for (uint8 i = 0; i < MAX_ELEMENTS; ++i) {
             assertEq(setStorage.elements[i].value, address(0));
         }
 


### PR DESCRIPTION
**EVC-01M**
[fix: audit Omniscia EVC-01M](https://github.com/euler-xyz/ethereum-vault-connector/pull/125/commits/de2fbb0710deb9078a64ded7cce302439b082a03)

**EVR-01M**
Needs Omniscia validation.

**EVR-02M**
Updated the [requirement](https://linear.app/euler-labs/issue/CER-49/re-entrancy)

**EVR-03M**
[fix: audit Omniscia EVR-03M](https://github.com/euler-xyz/ethereum-vault-connector/pull/125/commits/72ca9dff4bfaa449414dd66676e37fcfc1c00c2f)

**EVR-04M**
[fix: audit Omniscia EVR-04M](https://github.com/euler-xyz/ethereum-vault-connector/pull/125/commits/010e9e114c4e9e9e6a2962dc2eab936d2c64fc00)

**EVR-05M**
[fix: audit Omniscia EVR-05M](https://github.com/euler-xyz/ethereum-vault-connector/pull/125/commits/662f769644010464fd3eb8072d063613f1388ed1)

**EVR-06M**
We accept the fact that the controller’s `IVault::checkAccountStatus` function failure may result in inoperative account. The unopinionated nature of the Ethereum Vault Connector contract prohibit us from implementing a recommended grace period after which continuous account status failures would allow the controller to be removed.

Additionally, it must be noted that it is desired for the `IVault::checkAccountStatus` to revert deliberately due to invalid account status. Instead of updating the documentation to say that the function must not revert under any circumstances, it was updated to say that this function must only deliberately revert if the account status is invalid. The was a note added to emphasize the fact that if this function reverts due to any other reason, it may render the account unusable with possibly no way to recover funds.

**EVR-07M**
[fix: audit Omniscia EVR-07M](https://github.com/euler-xyz/ethereum-vault-connector/pull/125/commits/ba286b2b59143c3703505cac62545cba1c123a3c)

**EVR-08M**
[fix: audit Omniscia EVR-08M](https://github.com/euler-xyz/ethereum-vault-connector/pull/125/commits/066566a547884415e0ba2a90ed105627e511f5ed)