### PR TITLE
Delete comment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,14 @@
+{
+  "name": "ethereum-vault-connector",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ethereum-vault-connector",
+      "version": "1.0.0",
+      "license": "GPL-2.0-or-later",
+      "devDependencies": {}
+    }
+  }
+}

--- a/src/EthereumVaultConnector.sol
+++ b/src/EthereumVaultConnector.sol
@@ -494,8 +494,7 @@ contract EthereumVaultConnector is Events, Errors, TransientStorage, IEVC {
         bytes calldata data,
         bytes calldata signature
     ) public payable virtual nonReentrantChecksAndControlCollateral {
-        // cannot be called within the self-call of the permit function; can occur for nested calls.
-        // the permit function can be called only by the specified sender
+
         if (inPermitSelfCall() || (sender != address(0) && sender != msg.sender)) {
             revert EVC_NotAuthorized();
         }


### PR DESCRIPTION
The comment on ``EthereumVaultConnector#permit`` should be removed, as it may cause misunderstanding. 

The comment on ``IEVC#permit`` actually explains it well.

