### PR TITLE
Remove irrelevant comment

### DIFF
--- a/src/EthereumVaultConnector.sol
+++ b/src/EthereumVaultConnector.sol
@@ -495,7 +495,6 @@ contract EthereumVaultConnector is Events, Errors, TransientStorage, IEVC {
         bytes calldata signature
     ) public payable virtual nonReentrantChecksAndControlCollateral {
         // cannot be called within the self-call of the permit function; can occur for nested calls.
-        // the permit function can be called only by the specified sender
         if (inPermitSelfCall() || (sender != address(0) && sender != msg.sender)) {
             revert EVC_NotAuthorized();
         }


### PR DESCRIPTION
The comment on ``IEVC#permit`` actually explains it well.

So, the comment on ``EthereumVaultConnector#permit`` should be removed, as it may cause misunderstanding.
