### PR TITLE
CER-326: EVC Call/Batch always perform the enqueued account health checks

### DIFF
--- a/certora/conf/CER-40-AccountStatusCheck/CER-326-checkStatusAll-called.conf
+++ b/certora/conf/CER-40-AccountStatusCheck/CER-326-checkStatusAll-called.conf
@@ -12,5 +12,6 @@
   "optimistic_hashing": true,
   "prover_version": "master",
   "server": "production",
+  "coverage_info": "advanced",
   "prover_args": ["-smt_bitVectorTheory", "true"]
 }

--- a/certora/conf/CER-40-AccountStatusCheck/CER-326-checkStatusAll-called.conf
+++ b/certora/conf/CER-40-AccountStatusCheck/CER-326-checkStatusAll-called.conf
@@ -10,8 +10,6 @@
   "msg": "CER-40-AccountStatusCheck/CER-326-checkStatusAll-called",
   "optimistic_loop": true,
   "optimistic_hashing": true,
-  "prover_version": "master",
-  "server": "production",
   "coverage_info": "advanced",
   "prover_args": ["-smt_bitVectorTheory", "true"]
 }

--- a/certora/conf/CER-40-AccountStatusCheck/CER-326-checkStatusAll-called.conf
+++ b/certora/conf/CER-40-AccountStatusCheck/CER-326-checkStatusAll-called.conf
@@ -1,0 +1,16 @@
+{
+  "files": [
+    "certora/harness/EthereumVaultConnectorHarness.sol"
+  ],
+  "verify": "EthereumVaultConnectorHarness:certora/specs/CER-40-AccountStatusCheck/CER-326-checkStatusAll-called.spec",
+  "solc": "solc8.20",
+  "solc_optimize": "10000",
+  "rule_sanity": "basic",
+  "solc_via_ir": true,
+  "msg": "CER-40-AccountStatusCheck/CER-326-checkStatusAll-called",
+  "optimistic_loop": true,
+  "optimistic_hashing": true,
+  "prover_version": "master",
+  "server": "production",
+  "prover_args": ["-smt_bitVectorTheory", "true"]
+}

--- a/certora/specs/CER-40-AccountStatusCheck/CER-326-checkStatusAll-called.spec
+++ b/certora/specs/CER-40-AccountStatusCheck/CER-326-checkStatusAll-called.spec
@@ -1,0 +1,44 @@
+methods {
+    function EthereumVaultConnector.checkStatusAll(TransientStorage.SetType setType) internal => GhostCheckStatusAll();
+}
+
+persistent ghost bool checkCalled;
+
+function GhostCheckStatusAll() {
+    checkCalled = true;
+}
+
+rule checkStatusCalled_call {
+    env e;
+    require checkCalled == false;
+    address targetContract;
+    address onBehalfOfAccount;
+    uint256 value;
+    bytes data;
+    // Assume the initiall context did not defer checks. This
+    // can be checked manually by looking at the contstructor
+    require !getExecutionContextAreChecksDeferred(e);
+    call(e, targetContract, onBehalfOfAccount, value, data);
+    assert checkCalled;
+}
+
+rule checkStatusCalled_permit {
+    env e;
+    calldataarg args;
+
+    require checkCalled == false;
+    // Assume the initiall context did not defer checks
+    require !getExecutionContextAreChecksDeferred(e);
+    permit(e, args);
+    assert checkCalled;
+}
+
+rule checkStatusCalled_batch {
+    env e;
+    calldataarg args;
+    require checkCalled == false;
+    // Assume the initiall context did not defer checks
+    require !getExecutionContextAreChecksDeferred(e);
+    batch(e, args);
+    assert checkCalled;
+}

--- a/certora/specs/CER-40-AccountStatusCheck/CER-326-checkStatusAll-called.spec
+++ b/certora/specs/CER-40-AccountStatusCheck/CER-326-checkStatusAll-called.spec
@@ -22,17 +22,6 @@ rule checkStatusCalled_call {
     assert checkCalled;
 }
 
-rule checkStatusCalled_permit {
-    env e;
-    calldataarg args;
-
-    require checkCalled == false;
-    // Assume the initiall context did not defer checks
-    require !getExecutionContextAreChecksDeferred(e);
-    permit(e, args);
-    assert checkCalled;
-}
-
 rule checkStatusCalled_batch {
     env e;
     calldataarg args;

--- a/certora/specs/CER-40-AccountStatusCheck/CER-326-checkStatusAll-called.spec
+++ b/certora/specs/CER-40-AccountStatusCheck/CER-326-checkStatusAll-called.spec
@@ -8,6 +8,9 @@ function GhostCheckStatusAll() {
     checkCalled = true;
 }
 
+// Passing:
+// https://prover.certora.com/output/65266/2523dd890b324c9cb6c1fcec767e030e?anonymousKey=5c7f3132f51538a96a5d8d4fb0de61f4ed892ccc
+
 rule checkStatusCalled_call {
     env e;
     require checkCalled == false;
@@ -15,7 +18,7 @@ rule checkStatusCalled_call {
     address onBehalfOfAccount;
     uint256 value;
     bytes data;
-    // Assume the initiall context did not defer checks. This
+    // Assume the initial context did not defer checks. This
     // can be checked manually by looking at the contstructor
     require !getExecutionContextAreChecksDeferred(e);
     call(e, targetContract, onBehalfOfAccount, value, data);
@@ -26,8 +29,14 @@ rule checkStatusCalled_batch {
     env e;
     calldataarg args;
     require checkCalled == false;
-    // Assume the initiall context did not defer checks
+    // Assume the initial context did not defer checks
     require !getExecutionContextAreChecksDeferred(e);
     batch(e, args);
     assert checkCalled;
 }
+
+// Permit 
+// In permit, the targetContract on which the function is called
+// is hardcoded to be the EVC, so it gets converted into an ordinary
+// call op with a different caller. So the rule for call covers permit
+// as well.


### PR DESCRIPTION
We wanted to have a spec for this because we assume it for the holy grail rule.