### PR TITLE
test: support foundry v1.2

### DIFF
--- a/test/gas/SetGas.t.sol
+++ b/test/gas/SetGas.t.sol
@@ -84,10 +84,16 @@ contract SetGasTest is Test {
     function testGas_insert_size05_duplicateOfLast() public {
         size05.insert(ELEMENT_19);
     }
+ 
+    // Necessary to catch the revert, as otherwise the function call
+    // is inlined and the revert is not catched by `vm.expectRevert()`.
+    function _size10Insert(address element) public {
+        size10.insert(element);
+    }
 
-    function testGas_insert_siz10_reverts() public {
+    function testGas_insert_size10_reverts() public {
         vm.expectRevert();
-        size10.insert(ELEMENT_11);
+        this._size10Insert(ELEMENT_11);
     }
 
     function testGas_insert_size10_duplicateOfFirst() public {

--- a/test/unit/EthereumVaultConnector/Permit.t.sol
+++ b/test/unit/EthereumVaultConnector/Permit.t.sol
@@ -208,6 +208,7 @@ contract PermitTest is Test {
         bytes memory data,
         uint16 value
     ) public {
+        deadline = bound(deadline, 0, type(uint64).max - 1);
         vm.assume(
             privateKey > 0
                 && privateKey < 115792089237316195423570985008687907852837564279074904382605163141518161494337
@@ -263,6 +264,7 @@ contract PermitTest is Test {
         bytes calldata signature,
         uint16 value
     ) public {
+        deadline = bound(deadline, 0, type(uint64).max - 1);
         address alice = address(new SignerERC1271(evc));
         bytes19 addressPrefix = evc.getAddressPrefix(alice);
         address msgSender = sender == address(0) ? address(uint160(uint256(keccak256(abi.encode(alice))))) : sender;
@@ -313,6 +315,7 @@ contract PermitTest is Test {
         uint128 value,
         bytes memory data2
     ) public {
+        deadline = bound(deadline, 0, type(uint64).max - 1);
         vm.assume(
             privateKey > 0
                 && privateKey < 115792089237316195423570985008687907852837564279074904382605163141518161494337
@@ -357,6 +360,7 @@ contract PermitTest is Test {
         bytes memory data,
         bytes calldata signature
     ) public {
+        deadline = bound(deadline, 0, type(uint64).max - 1);
         vm.assume(
             privateKey > 0
                 && privateKey < 115792089237316195423570985008687907852837564279074904382605163141518161494337
@@ -392,6 +396,7 @@ contract PermitTest is Test {
         bytes memory data,
         bytes calldata signature
     ) public {
+        deadline = bound(deadline, 0, type(uint64).max - 1);
         alice = option % 3 == 0
             ? option % 2 == 0
                 ? address(uint160(bound(uint160(alice), 0, 0xFF)))
@@ -421,6 +426,7 @@ contract PermitTest is Test {
         bytes memory data,
         bytes calldata signature
     ) public {
+        deadline = bound(deadline, 0, type(uint64).max - 1);
         bytes19 addressPrefix = evc.getAddressPrefix(alice);
         data = abi.encode(keccak256(data));
         vm.assume(
@@ -456,6 +462,7 @@ contract PermitTest is Test {
         bytes memory data,
         bytes calldata signature
     ) public {
+        deadline = bound(deadline, 0, type(uint64).max - 1);
         bytes19 addressPrefix = evc.getAddressPrefix(alice);
         data = abi.encode(keccak256(data));
         vm.assume(
@@ -484,6 +491,7 @@ contract PermitTest is Test {
         uint128 value,
         bytes memory data
     ) public {
+        deadline = bound(deadline, 0, type(uint64).max - 1);
         vm.assume(
             privateKey > 0
                 && privateKey < 115792089237316195423570985008687907852837564279074904382605163141518161494337
@@ -526,6 +534,7 @@ contract PermitTest is Test {
         uint256 value,
         bytes calldata signature
     ) public {
+        deadline = bound(deadline, 0, type(uint64).max - 1);
         bytes19 addressPrefix = evc.getAddressPrefix(alice);
         vm.assume(
             !evc.haveCommonOwner(alice, address(0)) && !evc.haveCommonOwner(alice, EIP_7587_PRECOMPILES)
@@ -552,6 +561,7 @@ contract PermitTest is Test {
         uint128 value,
         bytes memory data
     ) public {
+        deadline = bound(deadline, 0, type(uint64).max - 1);
         vm.chainId(5); // for coverage
         vm.assume(
             privateKey > 0
@@ -603,6 +613,7 @@ contract PermitTest is Test {
         bytes calldata signature,
         uint16 value
     ) public {
+        deadline = bound(deadline, 0, type(uint64).max - 1);
         vm.assume(
             !evc.haveCommonOwner(signer, address(0)) && !evc.haveCommonOwner(signer, EIP_7587_PRECOMPILES)
                 && !evc.haveCommonOwner(signer, COMMON_PREDEPLOYS) && signer != address(evc)
@@ -627,6 +638,7 @@ contract PermitTest is Test {
     }
 
     function test_RevertIfInvalidECDSASignature_Permit(uint256 privateKey, uint128 deadline) public {
+        vm.assume(deadline < type(uint64).max);
         vm.assume(
             privateKey > 0
                 && privateKey < 115792089237316195423570985008687907852837564279074904382605163141518161494337
@@ -732,6 +744,7 @@ contract PermitTest is Test {
     }
 
     function test_RevertIfInvalidERC1271Signature_Permit(uint128 deadline, bytes calldata signature) public {
+        vm.assume(deadline < type(uint64).max);
         address alice = address(new SignerERC1271(evc));
         SignerERC1271(alice).setSignatureHash(signature);
 

--- a/test/unit/Set/Set.t.sol
+++ b/test/unit/Set/Set.t.sol
@@ -105,6 +105,12 @@ contract SetTest is Test {
         }
     }
 
+    // Necessary to catch the revert, as otherwise the function call
+    // is inlined and the revert is not catched by `vm.expectRevert()`.
+    function _insert(address element) public {
+        setStorage.insert(element);
+    }
+
     function test_RevertIfTooManyElements_Insert(uint256 seed) public {
         seed = bound(seed, 101, type(uint256).max);
         delete setStorage;
@@ -114,7 +120,7 @@ contract SetTest is Test {
         }
 
         vm.expectRevert(Set.TooManyElements.selector);
-        setStorage.insert(address(uint160(uint256(bytes32(keccak256(abi.encode(seed, seed)))))));
+        this._insert(address(uint160(uint256(bytes32(keccak256(abi.encode(seed, seed)))))));
     }
 
     function test_FirstElement_Insert(address element) public {
@@ -187,6 +193,12 @@ contract SetTest is Test {
         }
     }
 
+    // Necessary to catch the revert, as otherwise the function call
+    // is inlined and the revert is not catched by `vm.expectRevert()`.
+    function _reorder(uint8 index1, uint8 index2) public {
+      setStorage.reorder(index1, index2);
+    }
+
     function test_RevertIfInvalidIndex_Reorder(
         uint8 numberOfElements,
         address firstElement,
@@ -204,28 +216,28 @@ contract SetTest is Test {
         index2 = index1;
 
         vm.expectRevert(Set.InvalidIndex.selector);
-        setStorage.reorder(index1, index2);
+        this._reorder(index1, index2);
 
         // index1 is greater than index2
         index1 = uint8(bound(index1, 1, numberOfElements - 1));
         index2 = uint8(bound(index2, 0, index1 - 1));
 
         vm.expectRevert(Set.InvalidIndex.selector);
-        setStorage.reorder(index1, index2);
+        this._reorder(index1, index2);
 
         // both indices are out of bounds
         index1 = numberOfElements;
         index2 = numberOfElements + 1;
 
         vm.expectRevert(Set.InvalidIndex.selector);
-        setStorage.reorder(index1, index2);
+        this._reorder(index1, index2);
 
         // index2 is out of bounds
         index1 = uint8(bound(index1, 0, numberOfElements - 1));
         index2 = numberOfElements;
 
         vm.expectRevert(Set.InvalidIndex.selector);
-        setStorage.reorder(index1, index2);
+        this._reorder(index1, index2);
     }
 
     function test_setMetadata(uint80 metadata) public {


### PR DESCRIPTION
## Motivation

`foundry v1.2` upgraded to the newest `revm` version, which introduced breaking changes related to the max block time —reduced from `max(uint256)` to `max(uint64)`—.

additionally, during the following months, improving foundry's testing support will be once of the main goals. Because of that i'm trying to build a [benchmarking tool](https://github.com/0xrusowsky/foundry-benchmarks), that runs tests on state-of-the-art repos, to track the performance between foundry versions. Ideally this PR gets merged and wouldn't have to point to our own fork.

## Implementation

- bounds all the fuzz tests that use `uint256 deadline` to `type(uint64).max - 1`
- adds helper functions to tests that fail to catch the reverts cause the compiler seems to inline (and thus the revert happens in the same frame)