### PR TITLE
Fix failing tests, bump SET_MAX_ELEMENTS to 100

### DIFF
--- a/src/Set.sol
+++ b/src/Set.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 
 /// @dev Represents the maximum number of elements that can be stored in the set.
 /// Must not exceed 255 due to the uint8 data type limit.
-uint8 constant SET_MAX_ELEMENTS = 50;
+uint8 constant SET_MAX_ELEMENTS = 100;
 
 /// @title ElementStorage
 /// @notice This struct is used to store the value and stamp of an element.

--- a/test/gas/SetGas.t.sol
+++ b/test/gas/SetGas.t.sol
@@ -13,13 +13,14 @@ contract SetGasTest is Test {
     address constant ELEMENT_19 = address(19);
     address constant ELEMENT_10 = address(10);
     address constant ELEMENT_11 = address(11);
-    address constant ELEMENT_NOT_FOUND = address(99);
+    address constant ELEMENT_NOT_FOUND = address(uint160(SET_MAX_ELEMENTS) + 1);
 
     SetStorage size00;
     SetStorage size01;
     SetStorage size02;
     SetStorage size05;
     SetStorage size10;
+    SetStorage sizeMax;
 
     function setUp() public {
         size01.insert(ELEMENT_1);
@@ -34,6 +35,14 @@ contract SetGasTest is Test {
         for (uint160 i = 1; i <= 5; ++i) {
             size05.insert(address(i));
         }
+
+        for (uint160 i = 1; i <= SET_MAX_ELEMENTS; ++i) {
+            sizeMax.insert(address(i));
+        }
+    }
+
+    function externalInsertSizeMax(address element) external {
+        sizeMax.insert(element);
     }
 
     /**
@@ -85,9 +94,9 @@ contract SetGasTest is Test {
         size05.insert(ELEMENT_19);
     }
 
-    function testGas_insert_siz10_reverts() public {
+    function testGas_insert_sizeMax_reverts() public {
         vm.expectRevert();
-        size10.insert(ELEMENT_11);
+        this.externalInsertSizeMax(ELEMENT_NOT_FOUND);
     }
 
     function testGas_insert_size10_duplicateOfFirst() public {

--- a/test/invariants/EthereumVaultConnector.t.sol
+++ b/test/invariants/EthereumVaultConnector.t.sol
@@ -205,6 +205,8 @@ contract EthereumVaultConnectorHandler is EthereumVaultConnectorScribble, Test {
         bytes calldata signature
     ) public payable override {
         if (uint160(signer) <= 255 || signer == address(this)) return;
+        // skip foundry-reserved addresses (HEVM cheatcode, console) so vm.etch doesn't clobber them
+        if (signer == address(vm) || signer == CONSOLE) return;
         if (nonce == type(uint256).max) return;
         if (data.length == 0 || bytes4(data) == 0) return;
         vm.etch(signer, signerMock.code);

--- a/test/unit/EthereumVaultConnector/SetLockdownMode.t.sol
+++ b/test/unit/EthereumVaultConnector/SetLockdownMode.t.sol
@@ -72,10 +72,15 @@ contract SetLockdownModeTest is Test {
     }
 
     function test_Integration_SetLockdownMode(address alice, address vault, address operator) public {
+        // deploy upfront so vault can be excluded from these addresses in the assume below
+        address targetContract = address(new Target());
+        address controller = address(new Vault(evc));
+
         vm.assume(alice != address(0) && alice != address(evc) && !evc.haveCommonOwner(alice, operator));
         vm.assume(
             vault != address(0) && vault != address(evc) && vault != address(this) && vault != alice
-                && vault != operator && !evc.haveCommonOwner(vault, address(0)) && vault.code.length == 0
+                && vault != operator && vault != targetContract && vault != controller
+                && !evc.haveCommonOwner(vault, address(0)) && vault.code.length == 0
         );
         vm.assume(operator != address(0) && operator != address(evc));
 
@@ -128,7 +133,6 @@ contract SetLockdownModeTest is Test {
         vm.prank(alice);
         evc.setLockdownMode(addressPrefix, false);
 
-        address targetContract = address(new Target());
         bytes memory data = abi.encodeWithSelector(
             Target(targetContract).callTest.selector, address(evc), address(evc), 0, alice, false
         );
@@ -145,8 +149,6 @@ contract SetLockdownModeTest is Test {
         evc.call(targetContract, alice, 0, data);
 
         // control collateral works when not in lockdown mode
-        address controller = address(new Vault(evc));
-
         vm.prank(alice);
         evc.setLockdownMode(addressPrefix, false);
 

--- a/test/unit/Set/Set.t.sol
+++ b/test/unit/Set/Set.t.sol
@@ -16,6 +16,15 @@ contract SetTest is Test {
         delete expectedElements;
     }
 
+    // External wrappers used so vm.expectRevert can catch reverts from internal library calls.
+    function externalInsert(address element) external returns (bool) {
+        return setStorage.insert(element);
+    }
+
+    function externalReorder(uint8 index1, uint8 index2) external {
+        setStorage.reorder(index1, index2);
+    }
+
     // ----- AUXILIARY FOR TESTING -----
     SetStorage internal expectedElements;
 
@@ -114,7 +123,7 @@ contract SetTest is Test {
         }
 
         vm.expectRevert(Set.TooManyElements.selector);
-        setStorage.insert(address(uint160(uint256(bytes32(keccak256(abi.encode(seed, seed)))))));
+        this.externalInsert(address(uint160(uint256(bytes32(keccak256(abi.encode(seed, seed)))))));
     }
 
     function test_FirstElement_Insert(address element) public {
@@ -204,28 +213,28 @@ contract SetTest is Test {
         index2 = index1;
 
         vm.expectRevert(Set.InvalidIndex.selector);
-        setStorage.reorder(index1, index2);
+        this.externalReorder(index1, index2);
 
         // index1 is greater than index2
         index1 = uint8(bound(index1, 1, numberOfElements - 1));
         index2 = uint8(bound(index2, 0, index1 - 1));
 
         vm.expectRevert(Set.InvalidIndex.selector);
-        setStorage.reorder(index1, index2);
+        this.externalReorder(index1, index2);
 
         // both indices are out of bounds
         index1 = numberOfElements;
         index2 = numberOfElements + 1;
 
         vm.expectRevert(Set.InvalidIndex.selector);
-        setStorage.reorder(index1, index2);
+        this.externalReorder(index1, index2);
 
         // index2 is out of bounds
         index1 = uint8(bound(index1, 0, numberOfElements - 1));
         index2 = numberOfElements;
 
         vm.expectRevert(Set.InvalidIndex.selector);
-        setStorage.reorder(index1, index2);
+        this.externalReorder(index1, index2);
     }
 
     function test_setMetadata(uint80 metadata) public {


### PR DESCRIPTION
## Summary
- Bump `SET_MAX_ELEMENTS` from 50 to 100.
- Fix the test failures on this branch so the suite is green (179/179 passing locally).