### PR TITLE
chore: supply-chain hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,16 +6,19 @@ on:
           - master
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
           with:
               submodules: recursive
 
         - name: Install foundry
-          uses: foundry-rs/foundry-toolchain@v1
+          uses: foundry-rs/foundry-toolchain@82dee4ba654bd2146511f85f0d013af94670c4de # v1.4.0
           with:
               version: nightly
 
@@ -29,10 +32,10 @@ jobs:
       runs-on: ubuntu-latest
       needs: build
       steps:
-          - uses: actions/checkout@v3
+          - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
             with:
                 submodules: recursive
-          - uses: foundry-rs/foundry-toolchain@v1
+          - uses: foundry-rs/foundry-toolchain@82dee4ba654bd2146511f85f0d013af94670c4de # v1.4.0
             with:
                 version: nightly-c99854277c346fa6de7a8f9837230b36fd85850e
 
@@ -45,26 +48,26 @@ jobs:
       runs-on: ubuntu-latest
       needs: lint-check
       steps:
-          - uses: actions/checkout@v3
+          - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
             with:
                 submodules: recursive
-          - uses: foundry-rs/foundry-toolchain@v1
+          - uses: foundry-rs/foundry-toolchain@82dee4ba654bd2146511f85f0d013af94670c4de # v1.4.0
             with:
                 version: nightly-c99854277c346fa6de7a8f9837230b36fd85850e
           - name: Run foundry tests
             # --ast tests enables inline configs to work https://github.com/foundry-rs/foundry/issues/7310#issuecomment-1978088200
             run: |
-                forge test -vvv --gas-report --ast 
+                forge test -vvv --gas-report --ast
             id: test
 
   coverage:
       runs-on: ubuntu-latest
       needs: lint-check
       steps:
-          - uses: actions/checkout@v3
+          - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
             with:
                 submodules: recursive
-          - uses: foundry-rs/foundry-toolchain@v1
+          - uses: foundry-rs/foundry-toolchain@82dee4ba654bd2146511f85f0d013af94670c4de # v1.4.0
             with:
                 version: nightly-c99854277c346fa6de7a8f9837230b36fd85850e
           - name: Run foundry coverage


### PR DESCRIPTION
Solidity/Foundry repo with empty package.json — workflow-only hardening. ⚠ actions/checkout bumped v3→v4.