### PR TITLE
docs: align Set-backed limits with SET_MAX_ELEMENTS (100) and add boundary tests

### DIFF
--- a/src/interfaces/IEthereumVaultConnector.sol
+++ b/src/interfaces/IEthereumVaultConnector.sol
@@ -214,8 +214,8 @@ interface IEVC {
     /// @notice Enables a collateral for an account.
     /// @dev A collaterals is a vault for which account's balances are under the control of the currently enabled
     /// controller vault. Only the owner or an operator of the account can call this function. Unless it's a duplicate,
-    /// the collateral is added to the end of the array. There can be at most 10 unique collaterals enabled at a time.
-    /// Account status checks are performed.
+    /// the collateral is added to the end of the array. There can be at most SET_MAX_ELEMENTS (100) unique collaterals
+    /// enabled at a time. Account status checks are performed.
     /// @param account The account address for which the collateral is being enabled.
     /// @param vault The address being enabled as a collateral.
     function enableCollateral(address account, address vault) external payable;
@@ -261,9 +261,9 @@ interface IEVC {
     /// @notice Enables a controller for an account.
     /// @dev A controller is a vault that has been chosen for an account to have special control over account’s
     /// balances in the enabled collaterals vaults. Only the owner or an operator of the account can call this function.
-    /// Unless it's a duplicate, the controller is added to the end of the array. Transiently, there can be at most 10
-    /// unique controllers enabled at a time, but at most one can be enabled after the outermost checks-deferrable
-    /// call concludes. Account status checks are performed.
+    /// Unless it's a duplicate, the controller is added to the end of the array. Transiently, there can be at most
+    /// SET_MAX_ELEMENTS (100) unique controllers enabled at a time, but at most one can be enabled after the outermost
+    /// checks-deferrable call concludes. Account status checks are performed.
     /// @param account The address for which the controller is being enabled.
     /// @param vault The address of the controller being enabled.
     function enableController(address account, address vault) external payable;
@@ -394,9 +394,9 @@ interface IEVC {
 
     /// @notice Checks the status of an account and reverts if it is not valid.
     /// @dev If checks deferred, the account is added to the set of accounts to be checked at the end of the outermost
-    /// checks-deferrable call. There can be at most 10 unique accounts added to the set at a time. Account status
-    /// check is performed by calling into the selected controller vault and passing the array of currently enabled
-    /// collaterals. If controller is not selected, the account is always considered valid.
+    /// checks-deferrable call. There can be at most SET_MAX_ELEMENTS (100) unique accounts added to the set at a time.
+    /// Account status check is performed by calling into the selected controller vault and passing the array of
+    /// currently enabled collaterals. If controller is not selected, the account is always considered valid.
     /// @param account The address of the account to be checked.
     function requireAccountStatusCheck(address account) external payable;
 
@@ -415,8 +415,8 @@ interface IEVC {
 
     /// @notice Checks the status of a vault and reverts if it is not valid.
     /// @dev If checks deferred, the vault is added to the set of vaults to be checked at the end of the outermost
-    /// checks-deferrable call. There can be at most 10 unique vaults added to the set at a time. This function can
-    /// only be called by the vault itself.
+    /// checks-deferrable call. There can be at most SET_MAX_ELEMENTS (100) unique vaults added to the set at a time.
+    /// This function can only be called by the vault itself.
     function requireVaultStatusCheck() external payable;
 
     /// @notice Forgives previously deferred vault status check.

--- a/test/evc/EthereumVaultConnectorScribble.sol
+++ b/test/evc/EthereumVaultConnectorScribble.sol
@@ -13,12 +13,12 @@ import "../../src/EthereumVaultConnector.sol";
 /// #if_succeeds "on behalf of account is zero when checks in progress" executionContext.areChecksInProgress() ==> executionContext.getOnBehalfOfAccount() == address(0);
 /// #if_succeeds "account status checks set is empty 1" !old(executionContext.areChecksDeferred()) ==> old(accountStatusChecks.numElements) == 0 && accountStatusChecks.numElements == 0;
 /// #if_succeeds "account status checks set is empty 2" !old(executionContext.areChecksDeferred()) ==> old(accountStatusChecks.firstElement) == address(0) && accountStatusChecks.firstElement == address(0);
-/// #if_succeeds "account status checks set is empty 3" !old(executionContext.areChecksDeferred()) ==> forall(uint256 i in 0...10) accountStatusChecks.elements[i].value == address(0);
+/// #if_succeeds "account status checks set is empty 3" !old(executionContext.areChecksDeferred()) ==> forall(uint256 i in 0...SET_MAX_ELEMENTS) accountStatusChecks.elements[i].value == address(0);
 /// #if_succeeds "vault status checks set is empty 1" !old(executionContext.areChecksDeferred()) ==> old(vaultStatusChecks.numElements) == 0 && vaultStatusChecks.numElements == 0;
 /// #if_succeeds "vault status checks set is empty 2" !old(executionContext.areChecksDeferred()) ==> old(vaultStatusChecks.firstElement) == address(0) && vaultStatusChecks.firstElement == address(0);
-/// #if_succeeds "vault status checks set is empty 3" !old(executionContext.areChecksDeferred()) ==> forall(uint256 i in 0...10) vaultStatusChecks.elements[i].value == address(0);
-/// #invariant "account status checks set has at most 10 elements" accountStatusChecks.numElements <= 10;
-/// #invariant "vault status checks set has at most 10 elements" vaultStatusChecks.numElements <= 10;
+/// #if_succeeds "vault status checks set is empty 3" !old(executionContext.areChecksDeferred()) ==> forall(uint256 i in 0...SET_MAX_ELEMENTS) vaultStatusChecks.elements[i].value == address(0);
+/// #invariant "account status checks set has at most SET_MAX_ELEMENTS elements" accountStatusChecks.numElements <= SET_MAX_ELEMENTS;
+/// #invariant "vault status checks set has at most SET_MAX_ELEMENTS elements" vaultStatusChecks.numElements <= SET_MAX_ELEMENTS;
 contract EthereumVaultConnectorScribble is EthereumVaultConnector {
     using ExecutionContext for EC;
     using Set for SetStorage;
@@ -36,7 +36,7 @@ contract EthereumVaultConnectorScribble is EthereumVaultConnector {
     }
 
     /// #if_succeeds "is non-reentrant" !old(executionContext.areChecksInProgress()) && !old(executionContext.isControlCollateralInProgress());
-    /// #if_succeeds "the vault is present in the collateral set 1" old(accountCollaterals[account].numElements) < 10 ==> accountCollaterals[account].contains(vault);
+    /// #if_succeeds "the vault is present in the collateral set 1" old(accountCollaterals[account].numElements) < SET_MAX_ELEMENTS ==> accountCollaterals[account].contains(vault);
     /// #if_succeeds "number of vaults is equal to the collateral array length 1" accountCollaterals[account].numElements == accountCollaterals[account].get().length;
     /// #if_succeeds "collateral cannot be EVC" vault != address(this);
     function enableCollateral(address account, address vault) public payable virtual override {
@@ -58,7 +58,7 @@ contract EthereumVaultConnectorScribble is EthereumVaultConnector {
     }
 
     /// #if_succeeds "is non-reentrant" !old(executionContext.areChecksInProgress()) && !old(executionContext.isControlCollateralInProgress());
-    /// #if_succeeds "the vault is present in the controller set 1" old(accountControllers[account].numElements) < 10 ==> accountControllers[account].contains(vault);
+    /// #if_succeeds "the vault is present in the controller set 1" old(accountControllers[account].numElements) < SET_MAX_ELEMENTS ==> accountControllers[account].contains(vault);
     /// #if_succeeds "number of vaults is equal to the controller array length 1" accountControllers[account].numElements == accountControllers[account].get().length;
     /// #if_succeeds "controller cannot be EVC" vault != address(this);
     function enableController(address account, address vault) public payable virtual override {

--- a/test/gas/SetGas.t.sol
+++ b/test/gas/SetGas.t.sol
@@ -13,6 +13,7 @@ contract SetGasTest is Test {
     address constant ELEMENT_19 = address(19);
     address constant ELEMENT_10 = address(10);
     address constant ELEMENT_11 = address(11);
+    address constant ELEMENT_MAX = address(uint160(SET_MAX_ELEMENTS));
     address constant ELEMENT_NOT_FOUND = address(uint160(SET_MAX_ELEMENTS) + 1);
 
     SetStorage size00;
@@ -111,6 +112,18 @@ contract SetGasTest is Test {
         size10.insert(ELEMENT_10);
     }
 
+    function testGas_insert_sizeMax_duplicateOfFirst() public {
+        sizeMax.insert(ELEMENT_1);
+    }
+
+    function testGas_insert_sizeMax_duplicateOfSecond() public {
+        sizeMax.insert(ELEMENT_2);
+    }
+
+    function testGas_insert_sizeMax_duplicateOfLast() public {
+        sizeMax.insert(ELEMENT_MAX);
+    }
+
     /**
      *
      */
@@ -176,6 +189,22 @@ contract SetGasTest is Test {
         size10.contains(ELEMENT_10);
     }
 
+    function testGas_contains_sizeMax_notFound() public view {
+        sizeMax.contains(ELEMENT_NOT_FOUND);
+    }
+
+    function testGas_contains_sizeMax_foundAtFirst() public view {
+        sizeMax.contains(ELEMENT_1);
+    }
+
+    function testGas_contains_sizeMax_foundAtIndex1() public view {
+        sizeMax.contains(ELEMENT_2);
+    }
+
+    function testGas_contains_sizeMax_foundAtLastIndex() public view {
+        sizeMax.contains(ELEMENT_MAX);
+    }
+
     /**
      *
      */
@@ -239,5 +268,21 @@ contract SetGasTest is Test {
 
     function testGas_remove_size10_foundAtLastIndex() public {
         size10.remove(ELEMENT_10);
+    }
+
+    function testGas_remove_sizeMax_notFound() public {
+        sizeMax.remove(ELEMENT_NOT_FOUND);
+    }
+
+    function testGas_remove_sizeMax_foundAtFirst() public {
+        sizeMax.remove(ELEMENT_1);
+    }
+
+    function testGas_remove_sizeMax_foundAtIndex1() public {
+        sizeMax.remove(ELEMENT_2);
+    }
+
+    function testGas_remove_sizeMax_foundAtLastIndex() public {
+        sizeMax.remove(ELEMENT_MAX);
     }
 }

--- a/test/unit/EthereumVaultConnector/AccountStatus.t.sol
+++ b/test/unit/EthereumVaultConnector/AccountStatus.t.sol
@@ -102,6 +102,26 @@ contract AccountStatusTest is Test {
         }
     }
 
+    function test_BoundaryNumberOfAccounts_RequireAccountStatusCheck() external {
+        // deterministic boundary test: the account status checks set must support exactly SET_MAX_ELEMENTS elements.
+        // accounts are added to the set only while checks are deferred
+        evc.setChecksDeferred(true);
+
+        // schedule exactly SET_MAX_ELEMENTS distinct deferred account status checks
+        for (uint256 i = 0; i < SET_MAX_ELEMENTS; ++i) {
+            address account = address(uint160(uint256(keccak256(abi.encode("account", i)))));
+            evc.requireAccountStatusCheck(account);
+            assertTrue(evc.isAccountStatusCheckDeferred(account));
+        }
+
+        // scheduling one more account status check exceeds the Set capacity and reverts on the
+        // (SET_MAX_ELEMENTS + 1)-th element
+        address extraAccount = address(uint160(uint256(keccak256(abi.encode("account", SET_MAX_ELEMENTS)))));
+        vm.expectRevert(Set.TooManyElements.selector);
+        evc.requireAccountStatusCheck(extraAccount);
+        assertFalse(evc.isAccountStatusCheckDeferred(extraAccount));
+    }
+
     function test_RevertIfChecksReentrancy_RequireAccountStatusCheck(address account) external {
         evc.setChecksInProgress(true);
 

--- a/test/unit/EthereumVaultConnector/CollateralsManagement.t.sol
+++ b/test/unit/EthereumVaultConnector/CollateralsManagement.t.sol
@@ -171,6 +171,30 @@ contract CollateralsManagementTest is Test {
         }
     }
 
+    function test_BoundaryNumberOfCollaterals_CollateralsManagement() public {
+        // deterministic boundary test: the collateral set must support exactly SET_MAX_ELEMENTS elements
+        address alice = address(0xa11ce);
+
+        // enable exactly SET_MAX_ELEMENTS collaterals for the account
+        for (uint256 i = 0; i < SET_MAX_ELEMENTS; ++i) {
+            address vault = address(new Vault(evc));
+            vm.prank(alice);
+            evc.enableCollateral(alice, vault);
+        }
+
+        assertEq(evc.getCollaterals(alice).length, SET_MAX_ELEMENTS);
+
+        // enabling one more collateral exceeds the Set capacity and reverts on the (SET_MAX_ELEMENTS + 1)-th element
+        address extraVault = address(new Vault(evc));
+        vm.prank(alice);
+        vm.expectRevert(Set.TooManyElements.selector);
+        evc.enableCollateral(alice, extraVault);
+
+        // the collateral set still holds exactly SET_MAX_ELEMENTS elements
+        assertEq(evc.getCollaterals(alice).length, SET_MAX_ELEMENTS);
+        assertFalse(evc.isCollateralEnabled(alice, extraVault));
+    }
+
     function test_RevertIfNotOwnerOrNotOperator_CollateralsManagement(address alice, address bob) public {
         vm.assume(alice != address(0) && alice != address(evc) && bob != address(0) && bob != address(evc));
         vm.assume(!evc.haveCommonOwner(alice, bob));

--- a/test/unit/EthereumVaultConnector/VaultStatus.t.sol
+++ b/test/unit/EthereumVaultConnector/VaultStatus.t.sol
@@ -76,6 +76,28 @@ contract VaultStatusTest is Test {
         }
     }
 
+    function test_BoundaryNumberOfVaults_RequireVaultStatusCheck() external {
+        // deterministic boundary test: the vault status checks set must support exactly SET_MAX_ELEMENTS elements.
+        // vaults are added to the set only while checks are deferred
+        evc.setChecksDeferred(true);
+
+        // schedule exactly SET_MAX_ELEMENTS distinct deferred vault status checks
+        for (uint256 i = 0; i < SET_MAX_ELEMENTS; ++i) {
+            address vault = address(uint160(uint256(keccak256(abi.encode("vault", i)))));
+            vm.prank(vault);
+            evc.requireVaultStatusCheck();
+            assertTrue(evc.isVaultStatusCheckDeferred(vault));
+        }
+
+        // scheduling one more vault status check exceeds the Set capacity and reverts on the
+        // (SET_MAX_ELEMENTS + 1)-th element
+        address extraVault = address(uint160(uint256(keccak256(abi.encode("vault", SET_MAX_ELEMENTS)))));
+        vm.prank(extraVault);
+        vm.expectRevert(Set.TooManyElements.selector);
+        evc.requireVaultStatusCheck();
+        assertFalse(evc.isVaultStatusCheckDeferred(extraVault));
+    }
+
     function test_RevertIfChecksReentrancy_RequireVaultStatusCheck(uint8 index, uint8 vaultsNumber) external {
         vm.assume(index < vaultsNumber);
         vm.assume(vaultsNumber > 0 && vaultsNumber <= SET_MAX_ELEMENTS);


### PR DESCRIPTION
Addresses two informational audit findings on the SET_MAX_ELEMENTS increase (10 → 100).

## Finding 1 — stale `10` in `IEthereumVaultConnector.sol`
Updated the interface comments for `enableCollateral`, `enableController`, `requireAccountStatusCheck`, and `requireVaultStatusCheck` to reference `SET_MAX_ELEMENTS (100)`.

## Finding 2 — stale `10` in tests/specs
- `EthereumVaultConnectorScribble.sol`: replaced `10` literals with `SET_MAX_ELEMENTS` in the status-check `forall` ranges, the `numElements` invariants, and the `enableCollateral`/`enableController` postconditions.
- `SetGas.t.sol`: added a full-size 100-element worst-case gas suite (insert duplicates, contains, remove) on `sizeMax`.
- Added deterministic boundary tests that force exactly 100 elements and assert `Set.TooManyElements` on the 101st: collaterals, deferred account checks, deferred vault checks.

All affected unit/gas suites pass locally.